### PR TITLE
ci: allow maintained version on default branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,24 +50,13 @@ jobs:
           cache: false
 
       - name: Run go-semantic-release dry-run
-        id: next-version
         uses: go-semantic-release/action@48d83acd958dae62e73701aad20a5b5844a3bf45 # v1.23.0
         with:
           allow-initial-development-versions: true
+          custom-arguments: --allow-maintained-version-on-default-branch
           dry: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ inputs.prerelease }}
-
-      - name: Display dry-run output
-        run: |
-          echo "
-          major:      ${{ steps.next-version.outputs.version_major }}
-          minor:      ${{ steps.next-version.outputs.version_minor }}
-          patch:      ${{ steps.next-version.outputs.version_patch }}
-          prerelease: ${{ steps.next-version.outputs.version_prerelease }}
-
-          changelog:
-          ${{ steps.next-version.outputs.changelog }}"
 
   release:
     if: inputs.should_publish
@@ -99,6 +88,7 @@ jobs:
           allow-initial-development-versions: true
           changelog-file: docs/CHANGELOG.md
           changelog-generator-opt: emojis=true
+          custom-arguments: --allow-maintained-version-on-default-branch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           hooks: goreleaser
           prepend: true


### PR DESCRIPTION
# go-semantic-release: Allow maintained version on default branch

## Description

Add `custom-arguments: --allow-maintained-version-on-default-branch` option to `go-semantic-release` action

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] workflow

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
