### PR TITLE
Update version.go in built binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,20 +71,12 @@ jobs:
 
           .github/scripts/semver-util.sh print
 
-      - name: Update version.go
-        if: fromJSON(env.should_publish)
-        run: |
-          sed -E --in-place \
-            --expression='s/^(\tVersionMajor = )[0-9]+$/\1${{ steps.next-version.outputs.next-major }}/' \
-            --expression='s/^(\tVersionMinor = )[0-9]+$/\1${{ steps.next-version.outputs.next-minor }}/' \
-            --expression='s/^(\tVersionPatch = )[0-9]+$/\1${{ steps.next-version.outputs.next-patch }}/' \
-            --expression='s/^(\tVersionDev = )".*"$/\1"-${{ steps.next-version.outputs.next-dev }}"/' \
-            cmd/version.go
-
       - name: Push tag for next release
         if: fromJSON(env.should_publish)
-        uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
-        with:
-          commit_message: "chore(release): update version.go to ${{ steps.next-version.outputs.next-version }}"
-          file_pattern: cmd/version.go
-          tagging_message: ${{ steps.next-version.outputs.next-version }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          next_version="${{ steps.next-version.outputs.next-version }}"
+          git tag --annotate "${next_version}" --message="${next_version}"
+          git push --tags

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,12 @@ builds:
     flags: [-trimpath]
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
-    ldflags: -s -w -X=github.com/bomctl/bomctl/cmd.Version={{.Tag}} -X=github.com/bomctl/bomctl/cmd.BuildTime={{.Date}}
+    ldflags: -s -w
+      -X=github.com/bomctl/bomctl/cmd.VersionMajor={{.Major}}
+      -X=github.com/bomctl/bomctl/cmd.VersionMinor={{.Minor}}
+      -X=github.com/bomctl/bomctl/cmd.VersionPatch={{.Patch}}
+      -X=github.com/bomctl/bomctl/cmd.VersionDev={{.Dev}}
+      -X=github.com/bomctl/bomctl/cmd.BuildDate={{.Date}}
 
 signs:
   - id: cosign

--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,39 @@ BASH := ${shell type -p bash}
 SHELL := ${BASH}
 MAKEFILE ?= ${abspath ${firstword ${MAKEFILE_LIST}}}
 
+# ANSI color escape codes
+BOLD   := \033[1m
+CYAN   := \033[36m
+YELLOW := \033[33m
+RESET  := \033[0m
+
 # Default system architecture
 ARCH ?= amd64
 OS ?= linux
 
-# ANSI color escape codes
-BOLD ?= \033[1m
-CYAN ?= \033[36m
-GREEN ?= \033[32m
-RED ?= \033[31m
-YELLOW ?= \033[33m
-NC ?= \033[0m # No Color
+VERSION := ${shell git describe --tags --abbrev=0}
+VERSION ?= undefined
+
+GIT_SHA := ${shell git rev-parse HEAD}
+GIT_SHA ?= undefined
+
+BUILD_DATE := ${shell date -u +'%Y-%m-%dT%H:%M:%SZ'}
+
+VERSION_PARTS := ${subst ., ,${firstword ${subst -, ,${VERSION:v%=%}}}}
+
+VERSION_MAJOR := ${word 1,${VERSION_PARTS}}
+VERSION_MINOR := ${word 2,${VERSION_PARTS}}
+VERSION_PATCH := ${word 3,${VERSION_PARTS}}
+
+VERSION_DEV := ${lastword ${subst -, ,${VERSION}}}
+VERSION_DEV := ${if ${VERSION_DEV},-${VERSION_DEV},}
+
+LDFLAGS := -s -w \
+  -X=github.com/bomctl/bomctl/cmd.VersionMajor=${VERSION_MAJOR} \
+  -X=github.com/bomctl/bomctl/cmd.VersionMinor=${VERSION_MINOR} \
+  -X=github.com/bomctl/bomctl/cmd.VersionPatch=${VERSION_PATCH} \
+  -X=github.com/bomctl/bomctl/cmd.VersionDev=${VERSION_DEV} \
+  -X=github.com/bomctl/bomctl/cmd.BuildDate=${BUILD_DATE}
 
 ifeq (${OS},Windows_NT)
 	OS := windows
@@ -45,18 +67,14 @@ ifeq (${OS},windows)
 	TARGET_BIN := ${addsuffix .exe,${TARGET_BIN}}
 endif
 
-CLI_VERSION ?= ${if ${shell git describe --tags},${shell git describe --tags},"UnknownVersion"}
-GIT_SHA := ${if ${shell git rev-parse HEAD},${shell git rev-parse HEAD},""}
-BUILD_DATE := ${shell date -u +'%Y-%m-%dT%H:%M:%SZ'}
-
 .PHONY: all build clean help format test
 .SILENT: clean
 
 #@ Tools
 help: # Display this help
-	@awk 'BEGIN {FS = ":.*#"; printf "\n${YELLOW}Usage: make <target>${NC}\n"} \
-		/^[a-zA-Z_0-9-]+:.*?#/ { printf "  ${CYAN}%-20s${NC} %s\n", $$1, $$2 } \
-		/^#@/ { printf "\n${BOLD}%s${NC}\n", substr($$0, 4) }' ${MAKEFILE} && echo
+	@awk 'BEGIN {FS = ":.*#"; printf "\n${YELLOW}Usage: make <target>${RESET}\n"} \
+		/^[a-zA-Z_0-9-]+:.*?#/ { printf "  ${CYAN}%-20s${RESET} %s\n", $$1, $$2 } \
+		/^#@/ { printf "\n${BOLD}%s${RESET}\n", substr($$0, 4) }' ${MAKEFILE} && echo
 
 clean: # Clean the working directory
 	${RM} -r build
@@ -70,7 +88,7 @@ lint-fix: # Fix linter findings
 
 #@ Build
 define gobuild
-	CGO_ENABLED=0 GOOS=${1} GOARCH=${2} go build -trimpath -o build/bomctl-${1}-${2}${3}
+	CGO_ENABLED=0 GOOS=${1} GOARCH=${2} go build -trimpath -o dist/bomctl-${1}-${2}${3} -ldflags="${LDFLAGS}"
 endef
 
 build-linux-amd: # Build for Linux on AMD64

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,22 +24,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
+var (
+	// BuildDate is the date and time this binary was built.
+	BuildDate string
+
 	// VersionMajor is for an API incompatible changes.
-	VersionMajor = 0
+	VersionMajor string
 
 	// VersionMinor is for functionality in a backwards-compatible manner.
-	VersionMinor = 1
+	VersionMinor string
 
 	// VersionPatch is for backwards-compatible bug fixes.
-	VersionPatch = 0
+	VersionPatch string
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-alpha"
-)
+	VersionDev string
 
-// Version is the specification version that the package types support.
-var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)
+	// Version is the specification version that the package types support.
+	Version = fmt.Sprintf("v%s.%s.%s%s (built on %s)",
+		VersionMajor,
+		VersionMinor,
+		VersionPatch,
+		VersionDev,
+		BuildDate,
+	)
+)
 
 func versionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{


### PR DESCRIPTION
# Update version.go in built binary

## Description

Attempting to push a tagged commit to main during a workflow step fails the workflow. The tag is needed to trigger the `goreleaser` workflow.

Instead of trying to push a commit that modifies the file in the repository, build the binaries with `ldflags` that update the version variables in `version.go` for that build, then push only the new release tag.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Local build

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
