### PR TITLE
ci: update release structure 

### DIFF
--- a/.commitlint.yaml
+++ b/.commitlint.yaml
@@ -1,0 +1,55 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl authors
+# SPDX-FileName: .commitlint.yaml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+version: v0.10.1
+
+rules:
+  - body-max-line-length
+  - footer-max-line-length
+  - header-max-length
+  - header-min-length
+  - type-enum
+
+settings:
+  body-max-line-length:
+    argument: 72
+
+  footer-max-line-length:
+    argument: 72
+
+  header-max-length:
+    argument: 72
+
+  header-min-length:
+    argument: 10
+
+  type-enum:
+    argument:
+      - bug
+      - build
+      - chore
+      - ci
+      - docs
+      - feat
+      - fix
+      - perf
+      - refactor
+      - revert
+      - style
+      - test

--- a/.github/scripts/semver-util.sh
+++ b/.github/scripts/semver-util.sh
@@ -16,19 +16,24 @@ function usage {
 }
 
 function get_next {
-  local major minor patch dev version next_version
-  next_version="$(svu prerelease --pre-release alpha --strip-prefix)"
+  local current_branch
+  current_branch="$(git branch --show-current)"
 
-  # Split next_version string into components
-  IFS="-" read -r version dev <<< "${next_version#v}"
-  IFS="." read -r major minor patch <<< "$version"
-
-  echo "$major $minor $patch $dev"
+  if [[ $current_branch =~ ^alpha|dev$ ]]; then
+    svu prerelease --pre-release "$current_branch"
+  else
+    svu next
+  fi
 }
 
 function print_version {
-  local major minor patch dev
-  read -r major minor patch dev <<< "$(get_next)"
+  local next_version major minor patch pre
+
+  next_version="$(get_next)"
+
+  # Split next_version string into components
+  IFS="-" read -r version pre <<< "${next_version#v}"
+  IFS="." read -r major minor patch <<< "$version"
 
   release_info=(
     ""
@@ -38,7 +43,7 @@ function print_version {
     " ${BOLD}major${RESET} | ${GREEN}${major}${RESET}"
     " ${BOLD}minor${RESET} | ${GREEN}${minor}${RESET}"
     " ${BOLD}patch${RESET} | ${GREEN}${patch}${RESET}"
-    " ${BOLD}dev${RESET}   | ${YELLOW}${dev}${RESET}"
+    " ${BOLD}pre${RESET}   | ${YELLOW}${pre}${RESET}"
     "-------+---------"
     ""
   )

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl authors
+# SPDX-FileName: .github/workflows/commitlint.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+name: commitlint
+
+on:
+  push:
+    branches:
+      - "**"
+
+  pull_request:
+
+jobs:
+  lint:
+    if: ${{ !github.event.pull_request.merged }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install commitlint
+        run: go install github.com/conventionalcommit/commitlint@e9a606ce7074ac884ea091765be1651be18356d4 # v0.10.1
+
+      - name: Lint commit message
+        run: echo ${{ github.event.head_commit.message }} | commitlint lint

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -24,11 +24,11 @@ on:
     branches:
       - "**"
 
-  pull_request:
-
 jobs:
   lint:
-    if: ${{ !github.event.pull_request.merged }}
+    if: |
+      !startsWith(github.event.head_commit.message, 'Merge branch') &&
+      !startsWith(github.event.head_commit.message, 'Merge pull request')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -33,8 +33,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: "1.21"
+          cache: false
+
       - name: Install commitlint
         run: go install github.com/conventionalcommit/commitlint@e9a606ce7074ac884ea091765be1651be18356d4 # v0.10.1
 
       - name: Lint commit message
-        run: echo ${{ github.event.head_commit.message }} | commitlint lint
+        run: commitlint lint <<< '${{ github.event.head_commit.message }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GORELEASER_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GORELEASER_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,5 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           next_version="${{ steps.next-version.outputs.next-version }}"
-          git tag --sign --annotate "${next_version}" --message="${next_version}"
+          git tag --annotate "${next_version}" --message="${next_version}"
           git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,5 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           next_version="${{ steps.next-version.outputs.next-version }}"
-          git tag --annotate "${next_version}" --message="${next_version}"
+          git tag --sign --annotate "${next_version}" --message="${next_version}"
           git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
-      - cmd/version.go
 
 permissions:
   contents: read
@@ -58,18 +56,10 @@ jobs:
       - name: Get next release version
         id: next-version
         run: |
-          read -r major minor patch dev <<< "$(.github/scripts/semver-util.sh next)"
-
-          printf -v next_version "v%s.%s.%s" "$major" "$minor" "$patch"
-          [[ -n "$dev" ]] && next_version="${next_version}-${dev}"
+          next_version="$(.github/scripts/semver-util.sh next)"
+          .github/scripts/semver-util.sh print
 
           echo "next-version=${next_version}" >> "$GITHUB_OUTPUT"
-          echo "next-major=${major}" >> "$GITHUB_OUTPUT"
-          echo "next-minor=${minor}" >> "$GITHUB_OUTPUT"
-          echo "next-patch=${patch}" >> "$GITHUB_OUTPUT"
-          echo "next-dev=${dev}" >> "$GITHUB_OUTPUT"
-
-          .github/scripts/semver-util.sh print
 
       - name: Push tag for next release
         if: fromJSON(env.should_publish)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *
 
 # Whitelist patterns anchored to project root
+!/.commitlint.yaml
 !/.editorconfig
 !/.gitattributes
 !/.gitlab-ci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,21 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl authors
+# SPDX-FileName: .golangci.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
 ---
 run:
   concurrency: 6
@@ -24,11 +42,14 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bodyclose
     - dogsled
+    - dupl
     - errcheck
     - errorlint
     - exhaustive
     - exportloopref
+    - funlen
     - gci
     - gochecknoinits
     - gocognit
@@ -54,11 +75,13 @@ linters:
     - nakedret
     - nestif
     - predeclared
+    - revive
     - staticcheck
     - stylecheck
     - thelper
     - typecheck
     - unconvert
+    - unparam
     - unused
     - whitespace
     - wrapcheck
@@ -86,17 +109,7 @@ linters-settings:
   gocritic:
     enabled-checks:
       # Diagnostic
-      - appendAssign
-      - badCond
-      - caseOrder
-      - codegenComment
       - commentedOutCode
-      - deprecatedComment
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagName
       - nilValReturn
       - weakCond
       - octalLiteral
@@ -109,22 +122,13 @@ linters-settings:
 
       # Style
       - boolExprSimplify
-      - captLocal
-      - commentFormatting
       - commentedOutImport
-      - defaultCaseOrder
       - docStub
-      - elseif
       - emptyFallthrough
       - hexLiteral
-      - ifElseChain
       - methodExprCall
-      - singleCaseSwitch
       - typeAssertChain
-      - typeSwitchVar
-      - underef
       - unlabelStmt
-      - unlambda
 
       # Opinionated
       - builtinShadow

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,7 @@ signs:
     signature: $artifact.sig
     cmd: cosign
     args: [sign-blob, --output-signature=$artifact.sig, --key=env://COSIGN_PRIVATE_KEY, $artifact]
-    artifacts: binary
+    artifacts: checksum
 
 nfpms:
   - license: Apache License 2.0
@@ -69,7 +69,7 @@ nfpms:
 
 archives:
   - name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"
-    strip_parent_binary_folder: true
+    strip_binary_directory: true
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,9 +74,6 @@ archives:
       - goos: windows
         format: zip
 
-checksum:
-  name_template: "{{.ProjectName}}_checksums.txt"
-
 snapshot:
   name_template: SNAPSHOT-{{.ShortCommit}}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,17 +31,17 @@ before:
     - go mod tidy
 
 sboms:
-  - artifacts: binary
+  - artifacts: archive
     documents: [$artifact.cdx.json]
     cmd: syft
-    args: [$artifact, --output, cyclonedx-json=$document]
+    args: [scan, $artifact, --output, cyclonedx-json=$document]
 
 gomod:
+  mod: mod
   proxy: true
 
 builds:
-  - binary: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"
-    no_unique_dist_dir: true
+  - binary: "{{.ProjectName}}"
     mod_timestamp: "{{.CommitTimestamp}}"
     flags: [-trimpath]
     goos: [linux, darwin, windows]
@@ -50,7 +50,7 @@ builds:
       -X=github.com/bomctl/bomctl/cmd.VersionMajor={{.Major}}
       -X=github.com/bomctl/bomctl/cmd.VersionMinor={{.Minor}}
       -X=github.com/bomctl/bomctl/cmd.VersionPatch={{.Patch}}
-      -X=github.com/bomctl/bomctl/cmd.VersionDev={{if .Prerelease}}-{{.Prerelease}}{{else}}{{end}}
+      -X=github.com/bomctl/bomctl/cmd.VersionPre={{with .Prerelease}}-{{.}}{{end}}
       -X=github.com/bomctl/bomctl/cmd.BuildDate={{.Date}}
 
 signs:
@@ -68,9 +68,11 @@ nfpms:
     formats: [apk, deb, rpm]
 
 archives:
-  - format: binary
-    name_template: "{{.Binary}}"
-    allow_different_binary_count: true
+  - name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"
+    strip_parent_binary_folder: true
+    format_overrides:
+      - goos: windows
+        format: zip
 
 checksum:
   name_template: "{{.ProjectName}}_checksums.txt"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,8 +68,7 @@ nfpms:
     formats: [apk, deb, rpm]
 
 archives:
-  - name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"
-    strip_binary_directory: true
+  - strip_binary_directory: true
     format_overrides:
       - goos: windows
         format: zip

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,7 +66,9 @@
   "gitlens.showWelcomeOnInstall": false,
   "gitlens.showWhatsNewAfterUpgrades": false,
 
+  "git-graph.dialog.applyStash.reinstateIndex": true,
   "git-graph.dialog.fetchRemote.prune": true,
+  "git-graph.dialog.popStash.reinstateIndex": true,
   "git-graph.repository.commits.showSignatureStatus": true,
   "git-graph.repository.fetchAndPrune": true,
   "git-graph.repository.sign.commits": true,

--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,14 @@ VERSION_MAJOR := ${word 1,${VERSION_PARTS}}
 VERSION_MINOR := ${word 2,${VERSION_PARTS}}
 VERSION_PATCH := ${word 3,${VERSION_PARTS}}
 
-VERSION_DEV := ${lastword ${subst -, ,${VERSION}}}
-VERSION_DEV := ${if ${VERSION_DEV},-${VERSION_DEV},}
+VERSION_PRE := ${word 2,${subst -, ,${VERSION}}}
+VERSION_PRE := ${if ${VERSION_PRE},-${VERSION_PRE},}
 
 LDFLAGS := -s -w \
   -X=github.com/bomctl/bomctl/cmd.VersionMajor=${VERSION_MAJOR} \
   -X=github.com/bomctl/bomctl/cmd.VersionMinor=${VERSION_MINOR} \
   -X=github.com/bomctl/bomctl/cmd.VersionPatch=${VERSION_PATCH} \
-  -X=github.com/bomctl/bomctl/cmd.VersionDev=${VERSION_DEV} \
+  -X=github.com/bomctl/bomctl/cmd.VersionPre=${VERSION_PRE} \
   -X=github.com/bomctl/bomctl/cmd.BuildDate=${BUILD_DATE}
 
 ifeq (${OS},Windows_NT)
@@ -77,7 +77,7 @@ help: # Display this help
 		/^#@/ { printf "\n${BOLD}%s${RESET}\n", substr($$0, 4) }' ${MAKEFILE} && echo
 
 clean: # Clean the working directory
-	${RM} -r build
+	${RM} -r dist
 	find ${PWD} -name "*.log" -exec ${RM} {} \;
 
 lint: # Lint Golang code files

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -34,7 +34,7 @@ func fetchCmd() *cobra.Command {
 		PreRun: parsePositionalArgs,
 		Short:  "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Long:   "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			var err error
 			logger = utils.NewLogger("fetch")
 
@@ -66,7 +66,7 @@ func fetchCmd() *cobra.Command {
 	return fetchCmd
 }
 
-func parsePositionalArgs(cmd *cobra.Command, args []string) {
+func parsePositionalArgs(_ *cobra.Command, args []string) {
 	for _, arg := range args {
 		sbomURLs = append(sbomURLs, arg)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ func rootCmd() *cobra.Command {
 		Use:     "bomctl",
 		Long:    "Simpler Software Bill of Materials management",
 		Version: Version,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			if verbose {
 				log.SetLevel(log.DebugLevel)
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,7 +28,7 @@ var (
 	// BuildDate is the date and time this binary was built.
 	BuildDate string
 
-	// VersionMajor is for an API incompatible changes.
+	// VersionMajor is for breaking API changes.
 	VersionMajor string
 
 	// VersionMinor is for functionality in a backwards-compatible manner.
@@ -37,15 +37,15 @@ var (
 	// VersionPatch is for backwards-compatible bug fixes.
 	VersionPatch string
 
-	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev string
+	// VersionPre indicates prerelease branch.
+	VersionPre string
 
 	// Version is the specification version that the package types support.
 	Version = fmt.Sprintf("v%s.%s.%s%s (built on %s)",
 		VersionMajor,
 		VersionMinor,
 		VersionPatch,
-		VersionDev,
+		VersionPre,
 		BuildDate,
 	)
 )
@@ -55,7 +55,7 @@ func versionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Show version",
 		Long:  "Print the version",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Println("bomctl version", Version)
 		},
 	}

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -39,7 +39,7 @@ import (
 var errUnsupportedURL = errors.New("unsupported URL scheme")
 
 type Fetcher interface {
-	url.URLParser
+	url.Parser
 	Fetch(*url.ParsedURL, *url.BasicAuth) (*sbom.Document, error)
 }
 
@@ -48,15 +48,15 @@ func Exec(sbomURL, outputFile string, useNetRC bool) error {
 	logger := utils.NewLogger("fetch")
 
 	switch {
-	case (&oci.OCIFetcher{}).Parse(sbomURL) != nil:
+	case (&oci.Fetcher{}).Parse(sbomURL) != nil:
 		logger.Info("Fetching from OCI URL", "url", sbomURL)
-		fetcher = &oci.OCIFetcher{}
-	case (&git.GitFetcher{}).Parse(sbomURL) != nil:
+		fetcher = &oci.Fetcher{}
+	case (&git.Fetcher{}).Parse(sbomURL) != nil:
 		logger.Info("Fetching from Git URL", "url", sbomURL)
-		fetcher = &git.GitFetcher{}
-	case (&http.HTTPFetcher{}).Parse(sbomURL) != nil:
+		fetcher = &git.Fetcher{}
+	case (&http.Fetcher{}).Parse(sbomURL) != nil:
 		logger.Info("Fetching from HTTP URL", "url", sbomURL)
-		fetcher = &http.HTTPFetcher{OutputFile: outputFile}
+		fetcher = &http.Fetcher{OutputFile: outputFile}
 	default:
 		return fmt.Errorf("%w", errUnsupportedURL)
 	}
@@ -84,7 +84,7 @@ func Exec(sbomURL, outputFile string, useNetRC bool) error {
 	// Fetch externally referenced BOMs
 	var idx uint8
 	for _, ref := range utils.GetBOMReferences(document) {
-		idx += 1
+		idx++
 
 		if outputFile != "" {
 			// Matches base filename, excluding extension

--- a/internal/pkg/fetch/git/git.go
+++ b/internal/pkg/fetch/git/git.go
@@ -32,9 +32,9 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/utils"
 )
 
-type GitFetcher struct{}
+type Fetcher struct{}
 
-func (gf *GitFetcher) RegExp() *regexp.Regexp {
+func (fetcher *Fetcher) RegExp() *regexp.Regexp {
 	return regexp.MustCompile(
 		fmt.Sprintf("^%s%s%s%s%s$",
 			`((?:git\+)?(?P<scheme>https?|git|ssh):\/\/)?`,
@@ -46,9 +46,9 @@ func (gf *GitFetcher) RegExp() *regexp.Regexp {
 	)
 }
 
-func (gf *GitFetcher) Parse(fetchURL string) *url.ParsedURL {
+func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 	results := map[string]string{}
-	pattern := gf.RegExp()
+	pattern := fetcher.RegExp()
 	match := pattern.FindStringSubmatch(fetchURL)
 
 	for idx, name := range match {
@@ -72,7 +72,7 @@ func (gf *GitFetcher) Parse(fetchURL string) *url.ParsedURL {
 	}
 }
 
-func (gf *GitFetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
+func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
 	// Create temp directory to clone into
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "repo")
 	if err != nil {

--- a/internal/pkg/fetch/git/git_test.go
+++ b/internal/pkg/fetch/git/git_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestGitFetcherParse(t *testing.T) {
-	fetcher := &GitFetcher{}
+	fetcher := &Fetcher{}
 
 	for _, data := range []struct {
 		expected *url.ParsedURL

--- a/internal/pkg/fetch/http/http.go
+++ b/internal/pkg/fetch/http/http.go
@@ -33,11 +33,11 @@ import (
 
 var client = http.DefaultClient
 
-type HTTPFetcher struct {
+type Fetcher struct {
 	OutputFile string
 }
 
-func (hf *HTTPFetcher) RegExp() *regexp.Regexp {
+func (fetcher *Fetcher) RegExp() *regexp.Regexp {
 	return regexp.MustCompile(
 		fmt.Sprintf("%s%s%s%s",
 			`((?P<scheme>https?)://)`,
@@ -48,9 +48,9 @@ func (hf *HTTPFetcher) RegExp() *regexp.Regexp {
 	)
 }
 
-func (hf *HTTPFetcher) Parse(fetchURL string) *url.ParsedURL {
+func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 	results := map[string]string{}
-	pattern := hf.RegExp()
+	pattern := fetcher.RegExp()
 	match := pattern.FindStringSubmatch(fetchURL)
 
 	for idx, name := range match {
@@ -69,7 +69,7 @@ func (hf *HTTPFetcher) Parse(fetchURL string) *url.ParsedURL {
 	}
 }
 
-func (hf *HTTPFetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
+func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
 	req, err := http.NewRequest("GET", parsedURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
@@ -91,8 +91,8 @@ func (hf *HTTPFetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sb
 	}
 
 	// Create the file if specified at the command line
-	if hf.OutputFile != "" {
-		out, err := os.Create(hf.OutputFile)
+	if fetcher.OutputFile != "" {
+		out, err := os.Create(fetcher.OutputFile)
 		if err != nil {
 			return nil, fmt.Errorf("%w", err)
 		}

--- a/internal/pkg/fetch/http/http_test.go
+++ b/internal/pkg/fetch/http/http_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestHTTPFetcherParse(t *testing.T) {
-	fetcher := &HTTPFetcher{}
+	fetcher := &Fetcher{}
 
 	for _, data := range []struct {
 		expected *url.ParsedURL

--- a/internal/pkg/fetch/oci/oci.go
+++ b/internal/pkg/fetch/oci/oci.go
@@ -45,9 +45,9 @@ var (
 	memStore         = memory.New()
 )
 
-type OCIFetcher struct{}
+type Fetcher struct{}
 
-func (of *OCIFetcher) RegExp() *regexp.Regexp {
+func (fetcher *Fetcher) RegExp() *regexp.Regexp {
 	return regexp.MustCompile(
 		fmt.Sprintf("^%s%s%s%s%s$",
 			`((?P<scheme>oci|docker)(?:-archive)?:\/\/)?`,
@@ -59,9 +59,9 @@ func (of *OCIFetcher) RegExp() *regexp.Regexp {
 	)
 }
 
-func (of *OCIFetcher) Parse(fetchURL string) *url.ParsedURL {
+func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 	results := map[string]string{}
-	pattern := of.RegExp()
+	pattern := fetcher.RegExp()
 	match := pattern.FindStringSubmatch(fetchURL)
 
 	for idx, name := range match {
@@ -84,7 +84,7 @@ func (of *OCIFetcher) Parse(fetchURL string) *url.ParsedURL {
 	}
 }
 
-func (of *OCIFetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
+func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
 	var (
 		document                           *sbom.Document
 		err                                error

--- a/internal/pkg/fetch/oci/oci_test.go
+++ b/internal/pkg/fetch/oci/oci_test.go
@@ -29,7 +29,7 @@ import (
 const testSHA string = "sha256:abcdef0123456789ABCDEF0123456789abcdef0123456789ABCDEF0123456789"
 
 func TestOCIFetcherParse(t *testing.T) {
-	fetcher := &OCIFetcher{}
+	fetcher := &Fetcher{}
 
 	for _, data := range []struct {
 		expected *url.ParsedURL

--- a/internal/pkg/url/url.go
+++ b/internal/pkg/url/url.go
@@ -113,7 +113,7 @@ func (url *ParsedURL) String() string {
 	return string(urlBytes)
 }
 
-type URLParser interface {
+type Parser interface {
 	Parse(fetchURL string) *ParsedURL
 	RegExp() *regexp.Regexp
 }


### PR DESCRIPTION
# Update release structure

## Description

- instead of single binaries for each OS and arch, release an archive file that additionally contains README.md and CHANGELOG.md
- set to cut a regular (non-prerelease) release when pushing tag to main
- add more linters to `.golangci-lint.yml`, remove `gocritic` checks that are enabled by default to suppress warnings
  - the changed `.go` files are only addressing the new linter complaints
- add `commitlint` workflow to ensure conventional commit format

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Workflow runs

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings