### PR TITLE
chore: add golangci-lint linters and checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,38 +17,49 @@
 # limitations under the License.
 # ------------------------------------------------------------------------
 ---
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
+
 run:
   concurrency: 6
+  go: "1.21"
   timeout: 5m
 
 issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - forcetypeassert
+        - funlen
+        - goconst
+        - gocyclo
+
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50
   max-issues-per-linter: 0
+
   # Maximum count of issues with the same text.
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
+
   new-from-rev: ""
-  exclude-rules:
-    - path: '(.+)_test\.go'
-      linters:
-        - funlen
-        - goconst
-        - gocyclo
 
 linters:
   disable-all: true
   enable:
     - asciicheck
     - bodyclose
+    - cyclop
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
     - errorlint
     - exhaustive
     - exportloopref
+    - forbidigo
+    - forcetypeassert
     - funlen
     - gci
     - gochecknoinits
@@ -63,60 +74,81 @@ linters:
     - gofumpt
     - goheader
     - goimports
+    - gomnd
+    - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
     - gosimple
     - govet
+    - importas
     - ineffassign
     - lll
     - makezero
     - misspell
     - nakedret
     - nestif
+    - nilerr
+    - nlreturn
+    - noctx
+    - nolintlint
+    - prealloc
     - predeclared
+    - promlinter
     - revive
     - staticcheck
     - stylecheck
+    - tagliatelle
     - thelper
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
+    - wastedassign
     - whitespace
     - wrapcheck
+    - wsl
 
 linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
+
   exhaustive:
     # https://golangci-lint.run/usage/linters/#exhaustive
     default-signifies-exhaustive: true
+
   govet:
     enable:
       - fieldalignment
+
   godox:
     keywords:
       - BUG
       - FIXME
       - HACK
+
   gci:
     sections:
       - standard
       - default
       - prefix(github.com/bomctl/bomctl)
+
   gocritic:
     enabled-checks:
       # Diagnostic
       - commentedOutCode
       - nilValReturn
+      - sloppyReassign
       - weakCond
       - octalLiteral
 
       # Performance
       - appendCombine
+      - equalFold
       - hugeParam
+      - indexAlloc
       - rangeExprCopy
       - rangeValCopy
 
@@ -125,10 +157,13 @@ linters-settings:
       - commentedOutImport
       - docStub
       - emptyFallthrough
+      - emptyStringTest
       - hexLiteral
       - methodExprCall
+      - stringXbytes
       - typeAssertChain
       - unlabelStmt
+      - yodaStyleExpr
 
       # Opinionated
       - builtinShadow
@@ -138,4 +173,9 @@ linters-settings:
       - paramTypeCombine
       - ptrToRefParam
       - typeUnparen
+      - unnamedResult
       - unnecessaryBlock
+
+  nolintlint:
+    require-explanation: true
+    require-specific: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,7 +103,7 @@
   "prettier.printWidth": 120,
   "prettier.singleQuote": true,
 
-  "shellformat.flag": "--binary-next-line --keep-padding --case-indent --space-redirects --indent=2",
+  "shellformat.flag": "--keep-padding --case-indent --space-redirects --indent=2",
 
   "sqltools.autoConnectTo": ["bomctl"],
   "sqltools.connections": [

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 help: # Display this help
 	@awk 'BEGIN {FS = ":.*#"; printf "\n${YELLOW}Usage: make <target>${RESET}\n"} \
 		/^[a-zA-Z_0-9-]+:.*?#/ { printf "  ${CYAN}%-20s${RESET} %s\n", $$1, $$2 } \
-		/^#@/ { printf "\n${BOLD}%s${RESET}\n", substr($$0, 4) }' ${MAKEFILE} && echo
+		/^#@/ { printf "\n${BOLD}%s${RESET}\n", substr($$0, 4) }' ${MAKEFILE_LIST} && echo
 
 clean: # Clean the working directory
 	${RM} -r dist

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -75,39 +75,46 @@ func (usv *URLSliceValue) String() string       { return fmt.Sprintf("%v", *usv)
 func (dv *DirectoryValue) Set(value string) error {
 	checkDirectory(value)
 	*dv = DirectoryValue(value)
+
 	return nil
 }
 
 func (dsv *DirectorySliceValue) Set(value string) error {
 	checkDirectory(value)
 	*dsv = append(*dsv, value)
+
 	return nil
 }
 
 func (efv *ExistingFileValue) Set(value string) error {
 	checkFile(value)
 	*efv = ExistingFileValue(value)
+
 	return nil
 }
 
 func (fsv *FileSliceValue) Set(value string) error {
 	checkFile(value)
 	*fsv = append(*fsv, value)
+
 	return nil
 }
 
 func (ofv *OutputFileValue) Set(value string) error {
 	*ofv = OutputFileValue(value)
+
 	return nil
 }
 
 func (uv *URLValue) Set(value string) error {
 	*uv = URLValue(value)
+
 	return nil
 }
 
 func (usv *URLSliceValue) Set(value string) error {
 	*usv = append(*usv, value)
+
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,12 +36,14 @@ var (
 	verbose           bool
 )
 
+const readWriteExecuteUser = 0o700
+
 func initCache() {
 	if cache, err := os.UserCacheDir(); cacheDir == "" && err == nil {
 		cacheDir = filepath.Join(cache, "bomctl")
 	}
 
-	cobra.CheckErr(os.MkdirAll(cacheDir, os.FileMode(0o700)))
+	cobra.CheckErr(os.MkdirAll(cacheDir, os.FileMode(readWriteExecuteUser)))
 }
 
 func initConfig() {
@@ -52,7 +54,7 @@ func initConfig() {
 		cobra.CheckErr(err)
 
 		cfgDir = filepath.Join(cfgDir, "bomctl")
-		cobra.CheckErr(os.MkdirAll(cfgDir, os.FileMode(0o700)))
+		cobra.CheckErr(os.MkdirAll(cfgDir, os.FileMode(readWriteExecuteUser)))
 
 		viper.AddConfigPath(cfgDir)
 		viper.SetConfigType("yaml")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -56,7 +56,7 @@ func versionCmd() *cobra.Command {
 		Short: "Show version",
 		Long:  "Print the version",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println("bomctl version", Version)
+			fmt.Println("bomctl version", Version) //nolint:forbidigo // Print to terminal and exit
 		},
 	}
 

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -54,6 +54,7 @@ func CreateSchema(dbFile string) (*gorm.DB, error) {
 
 	if db != nil {
 		logger.Info("Database file already exists, will not recreate")
+
 		return db, nil
 	}
 

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -69,6 +69,7 @@ func parseFile(fileName string) *protobom.Document {
 
 func TestAddDocument(t *testing.T) {
 	var err error
+
 	db, err = CreateSchema(":memory:")
 	if err != nil {
 		t.FailNow()
@@ -102,6 +103,7 @@ func TestAddDocument(t *testing.T) {
 			err := AddDocument(data.document.(*mockDocument))
 			if data.expectedError != "" {
 				require.Errorf(t, err, data.expectedError, err)
+
 				return
 			}
 

--- a/internal/pkg/fetch/git/git.go
+++ b/internal/pkg/fetch/git/git.go
@@ -34,6 +34,10 @@ import (
 
 type Fetcher struct{}
 
+func (fetcher *Fetcher) Name() string {
+	return "Git"
+}
+
 func (fetcher *Fetcher) RegExp() *regexp.Regexp {
 	return regexp.MustCompile(
 		fmt.Sprintf("^%s%s%s%s%s$",

--- a/internal/pkg/fetch/http/http.go
+++ b/internal/pkg/fetch/http/http.go
@@ -19,6 +19,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,6 +36,10 @@ var client = http.DefaultClient
 
 type Fetcher struct {
 	OutputFile string
+}
+
+func (fetcher *Fetcher) Name() string {
+	return "HTTP"
 }
 
 func (fetcher *Fetcher) RegExp() *regexp.Regexp {
@@ -70,7 +75,7 @@ func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 }
 
 func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
-	req, err := http.NewRequest("GET", parsedURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", parsedURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}

--- a/internal/pkg/fetch/oci/oci.go
+++ b/internal/pkg/fetch/oci/oci.go
@@ -47,6 +47,10 @@ var (
 
 type Fetcher struct{}
 
+func (fetcher *Fetcher) Name() string {
+	return "OCI"
+}
+
 func (fetcher *Fetcher) RegExp() *regexp.Regexp {
 	return regexp.MustCompile(
 		fmt.Sprintf("^%s%s%s%s%s$",
@@ -123,6 +127,7 @@ func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*s
 
 func createRepository(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*remote.Repository, error) {
 	repoPath := strings.Trim(parsedURL.Hostname, "/") + "/" + strings.Trim(parsedURL.Path, "/")
+
 	repo, err := remote.NewRepository(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("error creating OCI registry repository %s: %w", repoPath, err)
@@ -164,8 +169,10 @@ func getManifestChildren(manifestDescriptor *ocispec.Descriptor) ([]ocispec.Desc
 }
 
 func getSBOMDescriptor(successors []ocispec.Descriptor) (*ocispec.Descriptor, error) {
-	var sbomDescriptor ocispec.Descriptor
-	var sbomDigests []string
+	var (
+		sbomDescriptor ocispec.Descriptor
+		sbomDigests    []string
+	)
 
 	for _, s := range successors {
 		if slices.Contains([]string{

--- a/internal/pkg/url/url.go
+++ b/internal/pkg/url/url.go
@@ -76,8 +76,10 @@ type ParsedURL struct {
 }
 
 func (url *ParsedURL) String() string {
-	var urlBytes []byte
-	pathSep := ""
+	var (
+		urlBytes []byte
+		pathSep  string
+	)
 
 	switch url.Scheme {
 	case "http", "https", "oci":

--- a/internal/pkg/utils/logger.go
+++ b/internal/pkg/utils/logger.go
@@ -24,11 +24,13 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+const levelWidth = 5
+
 func NewLogger(prefix string) *log.Logger {
 	// Set displayed width of log level in messages to show full level name
 	styles := log.DefaultStyles()
 	for _, level := range []log.Level{log.DebugLevel, log.ErrorLevel, log.FatalLevel, log.InfoLevel, log.WarnLevel} {
-		styles.Levels[level] = styles.Levels[level].MaxWidth(5).Width(5)
+		styles.Levels[level] = styles.Levels[level].MaxWidth(levelWidth).Width(levelWidth)
 	}
 
 	logger := log.NewWithOptions(os.Stdout, log.Options{Prefix: prefix, Level: log.GetLevel()})


### PR DESCRIPTION
# Add golangci-lint linters and checks

## Description

Add more linters and checks to the `.golangci-lint.yml` configuration. This is to increase code quality by enforcing stricter checks and to have a baseline set before more developers get involved.

## How Has This Been Tested?

- [X] Workflow runs

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings