### PR TITLE
fix: check if tag exists before attempting to push it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,22 @@ jobs:
 
           echo "next-version=${next_version}" >> "$GITHUB_OUTPUT"
 
-      - name: Push tag for next release
+      - name: Check if tag exists
         if: fromJSON(env.should_publish)
+        id: tag-exists
+        env:
+          NEXT_VERSION: ${{ steps.next-version.outputs.next-version }}
+        run: |
+          [[ -n $(git tag --list "$NEXT_VERSION") ]] && tag_exists="true" || tag_exists="false"
+          echo "tag-exists=${tag_exists}" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag for next release
+        if: fromJSON(steps.tag-exists.outputs.tag-exists) && fromJSON(env.should_publish)
+        env:
+          NEXT_VERSION: ${{ steps.next-version.outputs.next-version }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          next_version="${{ steps.next-version.outputs.next-version }}"
-          git tag --annotate "${next_version}" --message="${next_version}"
+          git tag --annotate "${NEXT_VERSION}" --message="${NEXT_VERSION}"
           git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           echo "tag-exists=${tag_exists}" >> "$GITHUB_OUTPUT"
 
       - name: Push tag for next release
-        if: fromJSON(steps.tag-exists.outputs.tag-exists) && fromJSON(env.should_publish)
+        if: fromJSON(env.should_publish) && fromJSON(steps.tag-exists.outputs.tag-exists)
         env:
           NEXT_VERSION: ${{ steps.next-version.outputs.next-version }}
         run: |


### PR DESCRIPTION
# Check if tag exists before attempting to push it

## Description

Update `release` job with check that if a tag with the generated next version already exists, don't attempt to push it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] workflow runs

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

Closes #24