### PR TITLE
chore: add SPDX generation to the release action

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,12 +31,14 @@ before:
     - go mod tidy
 
 sboms:
-  - artifacts: archive
+  - id: generate-cyclonedx
+    artifacts: archive
     documents: [$artifact.cdx.json]
     cmd: syft
     args: [scan, $artifact, --output, cyclonedx-json=$document]
 
-  - artifacts: archive
+  - id: generate-spdx
+    artifacts: archive
     documents: [$artifact.spdx.json]
     cmd: syft
     args: [scan, $artifact, --output, spdx-json=$document]


### PR DESCRIPTION
## Description

Adds SPDX SBOM generation support to the releases. This project strives to be SBOM format neutral and should generate both CDX and SPDX. 

Fixes #30.