### PR TITLE
fix: add commitlint workflow, only checks open PRs for valid titles

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl authors
+# SPDX-FileName: .github/workflows/commitlint.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+name: Ensure valid pull request title
+
+on:
+  pull_request:
+    branches:
+      - main
+      - next
+      - dev
+      - alpha
+      - "[0-9].x"
+      - "[0-9].[0-9].x"
+      - "[0-9].[0-9].[0-9].x"
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions: read-all
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: "1.21"
+          cache: false
+
+      - name: Install commitlint
+        run: go install github.com/conventionalcommit/commitlint@e9a606ce7074ac884ea091765be1651be18356d4 # v0.10.1
+
+      - name: Run commitlint against title of pull request
+        env:
+          PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+        run: commitlint lint <<< "${PULL_REQUEST_TITLE}"


### PR DESCRIPTION
# Ensure valid pull request titles using `commitlint`

## Description

Re-adding commitlint workflow but only to check titles of open PRs are valid.

