### PR TITLE
fix: backslash escaping in help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,7 +94,7 @@ func rootCmd() *cobra.Command {
 		fmt.Sprintf("cache directory [defaults:\n\t%s\n\t%s\n\t%s",
 			"Unix:    $HOME/.cache/bomctl",
 			"Darwin:  $HOME/Library/Caches/bomctl",
-			"Windows: %LocalAppData%\bomctl]",
+			"Windows: %LocalAppData%\\bomctl]",
 		),
 	)
 
@@ -102,7 +102,7 @@ func rootCmd() *cobra.Command {
 		fmt.Sprintf("config file [defaults:\n\t%s\n\t%s\n\t%s",
 			"Unix:    $HOME/.config/bomctl/bomctl.yaml",
 			"Darwin:  $HOME/Library/Application Support/bomctl/bomctl.yml",
-			"Windows: %AppData%\bomctl\bomctl.yml]",
+			"Windows: %AppData%\\bomctl\\bomctl.yml]",
 		),
 	)
 


### PR DESCRIPTION
# Fix backslash escaping in help text

## Description

Running `bomctl --help` currently shows:

```shell
      --cache-dir string   cache directory [defaults:
                                Unix:    $HOME/.cache/bomctl
                                Darwin:  $HOME/Library/Caches/bomctl
                                Windows: %LocalAppDataomctl]
      --config string      config file [defaults:
                                Unix:    $HOME/.config/bomctl/bomctl.yaml
                                Darwin:  $HOME/Library/Application Support/bomctl/bomctl.yml
                                Windows: %AppDataomctomctl.yml]
```

This fix corrects the windows paths to 

```shell
      --cache-dir string   cache directory [defaults:
                                Unix:    $HOME/.cache/bomctl
                                Darwin:  $HOME/Library/Caches/bomctl
                                Windows: %LocalAppData%\bomctl]
      --config string      config file [defaults:
                                Unix:    $HOME/.config/bomctl/bomctl.yaml
                                Darwin:  $HOME/Library/Application Support/bomctl/bomctl.yml
                                Windows: %AppData%\bomctl\bomctl.yml]
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
