### PR TITLE
docs: adding a CODEOWNERS to auto assign PR reviewers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !*.go
 !.gitignore
 !CODE_OF_CONDUCT.md
+!CODEOWNERS
 !CONTRIBUTING.md
 !COPYRIGHT.md
 !DEVELOPMENT.md

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# bomctl maintainers will be the default owners for everything in the repo
+
+*       @bomctl/maintainers


### PR DESCRIPTION
Small PR to add a `CODEOWNERS` file to auto assign reviewers for PRs.

Fixes #52