### PR TITLE
temporary Save command - Save SBOM to File By ID

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -35,10 +35,14 @@ type (
 	DirectorySliceValue []string
 	FileSliceValue      []string
 	URLSliceValue       []string
+	SBOMIDSliceValue    []string
 )
 
 var (
 	outputFile OutputFileValue
+	format     string
+	encoding   string
+	sbomIDs    SBOMIDSliceValue
 	sbomURLs   URLSliceValue
 	useNetRC   bool
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,6 +101,7 @@ func rootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug output")
 
 	rootCmd.AddCommand(fetchCmd())
+	rootCmd.AddCommand(saveCmd())
 	rootCmd.AddCommand(versionCmd())
 
 	return rootCmd

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -1,6 +1,6 @@
 // ------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl authors
-// SPDX-FileName: cmd/fetch.go
+// SPDX-FileName: cmd/save.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // ------------------------------------------------------------------------
@@ -23,23 +23,23 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bomctl/bomctl/internal/pkg/fetch"
+	"github.com/bomctl/bomctl/internal/pkg/save"
 	"github.com/bomctl/bomctl/internal/pkg/utils"
 )
 
-func fetchCmd() *cobra.Command {
-	fetchCmd := &cobra.Command{
-		Use:    "fetch [flags] SBOM_URL...",
+func saveCmd() *cobra.Command {
+	saveCmd := &cobra.Command{
+		Use:    "save [flags] SBOM_ID...",
 		Args:   cobra.MinimumNArgs(1),
-		PreRun: parseFetchPositionalArgs,
-		Short:  "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
-		Long:   "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
+		PreRun: parseSavePositionalArgs,
+		Short:  "Save SBOM file(s) from Storage",
+		Long:   "Save SBOM file(s) from Storage to Filesystem",
 		Run: func(_ *cobra.Command, _ []string) {
 			var err error
-			logger = utils.NewLogger("fetch")
+			logger = utils.NewLogger("save")
 
-			for _, url := range sbomURLs {
-				if err = fetch.Exec(url, outputFile.String(), useNetRC); err != nil {
+			for _, sbomID := range sbomIDs {
+				if err = save.Exec(sbomID, outputFile.String(), format, encoding); err != nil {
 					logger.Error(err)
 				}
 			}
@@ -50,24 +50,25 @@ func fetchCmd() *cobra.Command {
 		},
 	}
 
-	fetchCmd.Flags().VarP(
-		&outputFile,
-		"output-file",
-		"o",
-		"Path to output file",
-	)
-	fetchCmd.Flags().BoolVar(
-		&useNetRC,
-		"netrc",
-		false,
-		"Use .netrc file for authentication to remote hosts",
-	)
+	saveCmd.Flags().StringVarP(
+		&format,
+		"format",
+		"f",
+		"",
+		"output format [spdx, spdx-2.3, cyclonedx, cyclonedx-1.0, cyclonedx-1.1, cyclonedx-1.2, cyclonedx-1.3, cyclonedx-1.4, cyclonedx-1.5]")
 
-	return fetchCmd
+	saveCmd.Flags().StringVarP(
+		&encoding,
+		"encoding",
+		"e",
+		"json",
+		"the output encoding [spdx: [text, json] cyclonedx: [json]")
+
+	return saveCmd
 }
 
-func parseFetchPositionalArgs(_ *cobra.Command, args []string) {
+func parseSavePositionalArgs(_ *cobra.Command, args []string) {
 	for _, arg := range args {
-		sbomURLs = append(sbomURLs, arg)
+		sbomIDs = append(sbomIDs, arg)
 	}
 }

--- a/internal/pkg/save/save.go
+++ b/internal/pkg/save/save.go
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 bomctl authors
+// SPDX-FileName: internal/pkg/save/save.go
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// ------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+package save
+
+import (
+	"fmt"
+
+	"github.com/bomctl/bomctl/internal/pkg/db"
+	"github.com/bomctl/bomctl/internal/pkg/utils"
+	"github.com/bomctl/bomctl/internal/pkg/utils/format"
+
+	"github.com/protobom/protobom/pkg/writer"
+)
+
+func Exec(sbomID, outputFile, fs, encoding string) error {
+	logger := utils.NewLogger("save")
+
+	logger.Info(fmt.Sprintf("Saving %s SBOM ID", sbomID))
+
+	document, err := db.GetDocumentByID(sbomID)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	parsedFormat, err := format.Parse(fs, encoding)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	writer := writer.New(
+		writer.WithFormat(parsedFormat),
+	)
+
+	if err := writer.WriteFile(document, outputFile); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
+}

--- a/internal/pkg/utils/format/format.go
+++ b/internal/pkg/utils/format/format.go
@@ -1,0 +1,94 @@
+package format
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/protobom/protobom/pkg/formats"
+)
+
+var (
+	DefaultEncoding         = formats.JSON
+	DefaultSPDXJSONVersion  = formats.SPDX23JSON
+	DefaultSPDXTVVersion    = formats.SPDX23TV
+	DefaultCycloneDXVersion = formats.CDX15JSON
+	JSONFormatMap           = map[string]formats.Format{
+		"spdx":     formats.SPDXFORMAT,
+		"spdx-2.2": formats.SPDX22JSON,
+		"spdx-2.3": formats.SPDX23JSON,
+
+		"cyclonedx":     formats.CDXFORMAT,
+		"cyclonedx-1.0": formats.CDX10JSON,
+		"cyclonedx-1.1": formats.CDX11JSON,
+		"cyclonedx-1.2": formats.CDX12JSON,
+		"cyclonedx-1.3": formats.CDX13JSON,
+		"cyclonedx-1.4": formats.CDX14JSON,
+		"cyclonedx-1.5": formats.CDX15JSON,
+	}
+
+	TVFormatMap = map[string]formats.Format{
+		"spdx":     formats.SPDXFORMAT,
+		"spdx-2.2": formats.SPDX22TV,
+		"spdx-2.3": formats.SPDX23TV,
+	}
+
+	XMLFormatMap = map[string]formats.Format{}
+
+	JSONEncoding = formats.JSON
+	TEXTEncoding = formats.TEXT
+	SPDX         = formats.SPDXFORMAT
+	CDX          = formats.CDXFORMAT
+
+	EncodingMap = map[string]string{
+		"json": formats.JSON,
+		"xml":  formats.XML,
+		"text": formats.TEXT,
+	}
+)
+
+type Format struct {
+	formats.Format
+}
+
+// Parse parses the format string into a formats.Format
+func Parse(fs string, encoding string) (formats.Format, error) {
+	if fs == "" {
+		return formats.EmptyFormat, errors.New("no format specified")
+	}
+
+	s := strings.ToLower(fs)
+	var fm map[string]formats.Format
+
+	switch encoding {
+	case formats.JSON:
+		fm = JSONFormatMap
+	case formats.TEXT:
+		fm = TVFormatMap
+	case formats.XML:
+		fm = XMLFormatMap
+	default:
+		return formats.EmptyFormat,
+			fmt.Errorf("unknown encoding: %s", encoding)
+	}
+	f, ok := fm[s]
+	if !ok {
+		return formats.EmptyFormat, fmt.Errorf("unknown format: %s", fs)
+	}
+
+	if f == formats.SPDXFORMAT {
+		if encoding == formats.JSON {
+			return DefaultSPDXJSONVersion, nil
+		}
+
+		if encoding == formats.TEXT {
+			return DefaultSPDXTVVersion, nil
+		}
+	}
+
+	if f == formats.CDXFORMAT {
+		return DefaultCycloneDXVersion, nil
+	}
+
+	return f, nil
+}

--- a/internal/pkg/utils/format/format_test.go
+++ b/internal/pkg/utils/format/format_test.go
@@ -1,0 +1,55 @@
+package format_test
+
+import (
+	"testing"
+
+	"github.com/bomctl/bomctl/internal/pkg/utils/format"
+	"github.com/google/go-cmp/cmp"
+	"github.com/protobom/protobom/pkg/formats"
+)
+
+func Test_Parse(t *testing.T) {
+	tests := []struct {
+		name     string
+		fs       string
+		encoding string
+		want     formats.Format
+		wantErr  bool
+	}{
+		{
+			name:     "Parse spdx-2.2 json format",
+			fs:       "spdx-2.2",
+			encoding: formats.JSON,
+			want:     formats.SPDX22JSON,
+			wantErr:  false,
+		},
+		{
+			name:     "Parse spdx-2.3 json format",
+			fs:       "spdx-2.3",
+			encoding: formats.JSON,
+			want:     formats.SPDX23JSON,
+			wantErr:  false,
+		},
+		{
+			name:     "Parse spdx json format",
+			fs:       "spdx",
+			encoding: formats.JSON,
+			want:     format.DefaultSPDXJSONVersion,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := format.Parse(tt.fs, tt.encoding)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Suggestion for a `Save` Command, Considering @jhoward-lm [Comment](https://github.com/bomctl/bomctl/pull/33#issuecomment-2068182831).

Typically, users populate the database using the fetch command. This new command will allow users to save SBOMs to their local filesystem.

## Usage suggestion.
```yaml
Save SBOM file(s) from Storage to Filesystem

Usage:
  bomctl save [flags] SBOM_ID...

Flags:
  -e, --encoding string   the output encoding [spdx: [text, json] cyclonedx: [json] (default "json")
  -f, --format string     output format [spdx, spdx-2.3, cyclonedx, cyclonedx-1.0, cyclonedx-1.1, cyclonedx-1.2, cyclonedx-1.3, cyclonedx-1.4, cyclonedx-1.5]
  -h, --help              help for save

```

## Issues
1) Handling multiple SBOM IDs with a single output file:
Option 1: Output as tar archive
Option 2: Append index to file path
Option 3: Do not support multiple SBOM IDs in the command
Open to other suggestions
 
## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Waiting for feedback before implementing tests.
