### PR TITLE
refactor: pass file arguments as stream readers/writers instead of strings

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -35,11 +35,26 @@ func fetchCmd() *cobra.Command {
 		Short:  "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Long:   "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Run: func(_ *cobra.Command, _ []string) {
-			var err error
+			var (
+				err    error
+				output *os.File
+			)
+
 			logger = utils.NewLogger("fetch")
 
+			if string(outputFile) != "" {
+				out, err := os.Create(string(outputFile))
+				if err != nil {
+					logger.Fatal("error creating output file", "outputFile", outputFile)
+				}
+
+				output = out
+
+				defer output.Close()
+			}
+
 			for _, url := range sbomURLs {
-				if err = fetch.Exec(url, outputFile.String(), useNetRC); err != nil {
+				if err = fetch.Fetch(url, output, useNetRC); err != nil {
 					logger.Error(err)
 				}
 			}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -43,6 +43,10 @@ func fetchCmd() *cobra.Command {
 			logger = utils.NewLogger("fetch")
 
 			if string(outputFile) != "" {
+				if len(sbomURLs) > 1 {
+					logger.Fatal("The --output-file option cannot be used when more than one URL is provided.")
+				}
+
 				if output, err = os.Create(string(outputFile)); err != nil {
 					logger.Fatal("error creating output file", "outputFile", outputFile)
 				}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -43,12 +43,9 @@ func fetchCmd() *cobra.Command {
 			logger = utils.NewLogger("fetch")
 
 			if string(outputFile) != "" {
-				out, err := os.Create(string(outputFile))
-				if err != nil {
+				if output, err = os.Create(string(outputFile)); err != nil {
 					logger.Fatal("error creating output file", "outputFile", outputFile)
 				}
-
-				output = out
 
 				defer output.Close()
 			}

--- a/internal/pkg/fetch/git/git.go
+++ b/internal/pkg/fetch/git/git.go
@@ -26,10 +26,8 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/protobom/protobom/pkg/sbom"
 
 	"github.com/bomctl/bomctl/internal/pkg/url"
-	"github.com/bomctl/bomctl/internal/pkg/utils"
 )
 
 type Fetcher struct{}
@@ -83,8 +81,8 @@ func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 	}
 }
 
-func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
-	// Create temp directory to clone into
+func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) ([]byte, error) {
+	// Create temp directory to clone into.
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "repo")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
@@ -118,16 +116,10 @@ func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*s
 	}
 
 	// Read the file specified in the URL fragment
-	sbomBytes, err := os.ReadFile(filepath.Join(tmpDir, parsedURL.Fragment))
+	sbomData, err := os.ReadFile(filepath.Join(tmpDir, parsedURL.Fragment))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", parsedURL.Fragment, err)
 	}
 
-	// Parse the file content
-	document, err := utils.ParseSBOMData(sbomBytes)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing SBOM file content: %w", err)
-	}
-
-	return document, nil
+	return sbomData, nil
 }

--- a/internal/pkg/fetch/http/http.go
+++ b/internal/pkg/fetch/http/http.go
@@ -23,20 +23,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 
-	"github.com/protobom/protobom/pkg/sbom"
-
 	"github.com/bomctl/bomctl/internal/pkg/url"
-	"github.com/bomctl/bomctl/internal/pkg/utils"
 )
 
-var client = http.DefaultClient
-
-type Fetcher struct {
-	OutputFile string
-}
+type Fetcher struct{}
 
 func (fetcher *Fetcher) Name() string {
 	return "HTTP"
@@ -81,47 +73,25 @@ func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 	}
 }
 
-func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
+func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) ([]byte, error) {
 	req, err := http.NewRequestWithContext(context.Background(), "GET", parsedURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, fmt.Errorf("failed creating request to %s: %w", parsedURL.String(), err)
 	}
 
 	auth.SetAuth(req)
 
-	// Get the data
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, fmt.Errorf("failed request to %s: %w", parsedURL.String(), err)
 	}
 
 	defer resp.Body.Close()
 
-	respBytes, err := io.ReadAll(resp.Body)
+	sbomData, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, fmt.Errorf("error reading response: %w", err)
 	}
 
-	// Create the file if specified at the command line
-	if fetcher.OutputFile != "" {
-		out, err := os.Create(fetcher.OutputFile)
-		if err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-
-		defer out.Close()
-
-		// Write the response body to file
-		_, err = io.Copy(out, resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-	}
-
-	document, err := utils.ParseSBOMData(respBytes)
-	if err != nil {
-		return nil, fmt.Errorf("%w", err)
-	}
-
-	return document, nil
+	return sbomData, nil
 }

--- a/internal/pkg/fetch/oci/oci.go
+++ b/internal/pkg/fetch/oci/oci.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/protobom/protobom/pkg/sbom"
 	oras "oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
@@ -36,7 +35,6 @@ import (
 	"oras.land/oras-go/v2/registry/remote/retry"
 
 	"github.com/bomctl/bomctl/internal/pkg/url"
-	"github.com/bomctl/bomctl/internal/pkg/utils"
 )
 
 var (
@@ -107,9 +105,8 @@ func (fetcher *Fetcher) Parse(fetchURL string) *url.ParsedURL {
 	}
 }
 
-func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*sbom.Document, error) {
+func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) ([]byte, error) {
 	var (
-		document                           *sbom.Document
 		err                                error
 		manifestDescriptor, sbomDescriptor *ocispec.Descriptor
 		repo                               *remote.Repository
@@ -137,11 +134,7 @@ func (fetcher *Fetcher) Fetch(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*s
 		return nil, err
 	}
 
-	if document, err = utils.ParseSBOMData(sbomData); err != nil {
-		return nil, fmt.Errorf("error parsing SBOM file content: %w", err)
-	}
-
-	return document, nil
+	return sbomData, nil
 }
 
 func createRepository(parsedURL *url.ParsedURL, auth *url.BasicAuth) (*remote.Repository, error) {


### PR DESCRIPTION
# Pass file arguments as stream readers/writers instead of strings

## Description

## Type of change

Please delete options that are not relevant.

- [X] Refactor

## How Has This Been Tested?

- [X] Local testing

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings