### PR TITLE
feat: add push subcommand cli

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -35,13 +35,13 @@ func pushCmd() *cobra.Command {
 	}
 
 	pushCmd := &cobra.Command{
-		Use:    "push [flags] SBOM_ID DEST_PATH...",
+		Use:    "push [flags] SBOM_ID [SBOM_ID...] DEST_PATH",
 		Args:   cobra.MinimumNArgs(pushArgNum),
 		Short:  "Push stored SBOM file(s) to remote URL or filesystem",
 		Long:   "Push stored SBOM file(s) to remote URL or filesystem",
 		PreRun: preRun(opts.Options),
 		Run: func(_ *cobra.Command, args []string) {
-			if err := push.Push(args[0], args[1], opts); err != nil {
+			if err := push.Push(args[:len(args)-1], args[len(args)-1], opts); err != nil {
 				opts.Logger.Fatal(err)
 			}
 		},

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,56 @@
+// ------------------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+// SPDX-FileName: cmd/push.go
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// ------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+package cmd
+
+import (
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/spf13/cobra"
+
+	"github.com/bomctl/bomctl/internal/pkg/options"
+	"github.com/bomctl/bomctl/internal/pkg/push"
+	"github.com/bomctl/bomctl/internal/pkg/utils"
+)
+
+const pushArgNum = 2
+
+func pushCmd() *cobra.Command {
+	opts := &push.Options{
+		Options: options.New(options.WithLogger(utils.NewLogger("push"))),
+	}
+
+	pushCmd := &cobra.Command{
+		Use:    "push [flags] SBOM_ID DEST_PATH...",
+		Args:   cobra.MinimumNArgs(pushArgNum),
+		Short:  "Push SBOM file(s) to HTTP(S) URLs, OCI, Git Repos, FileSystem",
+		Long:   "Push SBOM file(s) to HTTP(S) URLs, OCI, Git Repos, FileSystem",
+		PreRun: preRun(opts.Options),
+		Run: func(_ *cobra.Command, args []string) {
+			if err := push.Push(args[0], args[1], opts); err != nil {
+				opts.Logger.Fatal(err)
+			}
+		},
+	}
+
+	pushCmd.Flags().StringP("encoding", "e", formats.JSON, encodingHelp())
+	pushCmd.Flags().StringP("format", "f", formats.CDXFORMAT, formatHelp())
+	pushCmd.Flags().BoolVar(&opts.UseNetRC, "netrc", false, "Use .netrc file for authentication to remote hosts")
+	pushCmd.Flags().BoolVar(&opts.UseTree, "tree", false, "Push all Sboms in Tree to specified Destination")
+
+	return pushCmd
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -37,8 +37,8 @@ func pushCmd() *cobra.Command {
 	pushCmd := &cobra.Command{
 		Use:    "push [flags] SBOM_ID DEST_PATH...",
 		Args:   cobra.MinimumNArgs(pushArgNum),
-		Short:  "Push SBOM file(s) to HTTP(S) URLs, OCI, Git Repos, FileSystem",
-		Long:   "Push SBOM file(s) to HTTP(S) URLs, OCI, Git Repos, FileSystem",
+		Short:  "Push stored SBOM file(s) to remote URL or filesystem",
+		Long:   "Push stored SBOM file(s) to remote URL or filesystem",
 		PreRun: preRun(opts.Options),
 		Run: func(_ *cobra.Command, args []string) {
 			if err := push.Push(args[0], args[1], opts); err != nil {
@@ -50,7 +50,7 @@ func pushCmd() *cobra.Command {
 	pushCmd.Flags().StringP("encoding", "e", formats.JSON, encodingHelp())
 	pushCmd.Flags().StringP("format", "f", formats.CDXFORMAT, formatHelp())
 	pushCmd.Flags().BoolVar(&opts.UseNetRC, "netrc", false, "Use .netrc file for authentication to remote hosts")
-	pushCmd.Flags().BoolVar(&opts.UseTree, "tree", false, "Push all Sboms in Tree to specified Destination")
+	pushCmd.Flags().BoolVar(&opts.UseTree, "tree", false, "Recursively push all SBOMs in external reference tree")
 
 	return pushCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,7 @@ func rootCmd() *cobra.Command {
 	rootCmd.AddCommand(fetchCmd())
 	rootCmd.AddCommand(importCmd())
 	rootCmd.AddCommand(listCmd())
+	rootCmd.AddCommand(pushCmd())
 	rootCmd.AddCommand(versionCmd())
 
 	return rootCmd

--- a/internal/pkg/push/push.go
+++ b/internal/pkg/push/push.go
@@ -1,0 +1,130 @@
+// ------------------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+// SPDX-FileName: internal/pkg/push/push.go
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// ------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+package push
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jdx/go-netrc"
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/sbom"
+
+	"github.com/bomctl/bomctl/internal/pkg/db"
+	"github.com/bomctl/bomctl/internal/pkg/options"
+	"github.com/bomctl/bomctl/internal/pkg/url"
+)
+
+var errUnsupportedURL = errors.New("failed to parse URL; see `bomctl push --help` for valid URL patterns")
+
+type (
+	Pusher interface {
+		url.Parser
+		Push(*sbom.Document, *url.ParsedURL, *url.BasicAuth) error
+		Name() string
+	}
+
+	Options struct {
+		*options.Options
+		Format   formats.Format
+		UseNetRC bool
+		UseTree  bool
+	}
+)
+
+func Push(sbomID, destPath string, opts *Options) error {
+	backend := db.NewBackend().
+		Debug(opts.Debug).
+		WithDatabaseFile(filepath.Join(opts.CacheDir, db.DatabaseFile)).
+		WithLogger(opts.Logger)
+
+	if err := backend.InitClient(); err != nil {
+		return fmt.Errorf("failed to initialize backend client: %w", err)
+	}
+
+	defer backend.CloseClient()
+
+	// Insert pushed document data into database.
+	document, err := backend.GetDocumentByID(sbomID)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	// Push externally referenced BOMs
+	return pushDocument(document, destPath, opts)
+}
+
+func NewPusher(sbomURL string) (Pusher, error) {
+	for _, pusher := range []Pusher{} {
+		if parsedURL := pusher.Parse(sbomURL); parsedURL != nil {
+			return pusher, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", errUnsupportedURL, sbomURL)
+}
+
+func pushDocument(document *sbom.Document, destPath string, opts *Options) error {
+	opts.Logger.Info("Pushing Document", "sbomID", document.Metadata.Id)
+
+	pusher, err := NewPusher(destPath)
+	if err != nil {
+		return err
+	}
+
+	opts.Logger.Info(fmt.Sprintf("Pushing to %s URL", pusher.Name()), "url", destPath)
+
+	parsedURL := pusher.Parse(destPath)
+	auth := &url.BasicAuth{Username: parsedURL.Username, Password: parsedURL.Password}
+
+	if opts.UseNetRC {
+		if err := setNetRCAuth(parsedURL.Hostname, auth); err != nil {
+			return err
+		}
+	}
+
+	err = pusher.Push(document, parsedURL, auth)
+	if err != nil {
+		return fmt.Errorf("failed to push from %s: %w", parsedURL, err)
+	}
+
+	return nil
+}
+
+func setNetRCAuth(hostname string, auth *url.BasicAuth) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	authFile, err := netrc.Parse(filepath.Join(home, ".netrc"))
+	if err != nil {
+		return fmt.Errorf("failed to parse .netrc file: %w", err)
+	}
+
+	// Use credentials in .netrc if entry for the hostname is found
+	if machine := authFile.Machine(hostname); machine != nil {
+		auth.Username = machine.Get("login")
+		auth.Password = machine.Get("password")
+	}
+
+	return nil
+}

--- a/internal/pkg/push/push.go
+++ b/internal/pkg/push/push.go
@@ -72,7 +72,7 @@ func Push(sbomID, destPath string, opts *Options) error {
 	return pushDocument(document, destPath, opts)
 }
 
-func NewPusher(sbomURL string) (Pusher, error) {
+func New(sbomURL string) (Pusher, error) {
 	for _, pusher := range []Pusher{} {
 		if parsedURL := pusher.Parse(sbomURL); parsedURL != nil {
 			return pusher, nil


### PR DESCRIPTION
# Pull Request Template

## Description

Adds base cli cmd and options for push subcommand. As well as base scaffolding in pkg/internal to begin adding client functionality. 

Future PRs would add client functionality for oci/http/git, etc

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

No unit tests added yet

Related to #46 
