### PR TITLE
fix: recursive fetching and outputting of recursive files

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -42,24 +42,22 @@ func fetchCmd() *cobra.Command {
 		Long:   "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		PreRun: preRun(opts.Options),
 		Run: func(_ *cobra.Command, args []string) {
-			var outputFile *os.File
-
-			if string(outputFileName) != "" {
+			if outputFileName != "" {
 				if len(args) > 1 {
 					opts.Logger.Fatal("The --output-file option cannot be used when more than one URL is provided.")
 				}
 
 				out, err := os.Create(string(outputFileName))
 				if err != nil {
-					opts.Logger.Fatal("error creating output file", "outputFile", outputFile)
+					opts.Logger.Fatal("error creating output file", "outputFileName", outputFileName)
 				}
 
-				outputFile = out
-				defer outputFile.Close()
+				opts.OutputFile = out
+				defer opts.OutputFile.Close()
 			}
 
 			for _, url := range args {
-				if err := fetch.Fetch(url, opts, outputFile); err != nil {
+				if err := fetch.Fetch(url, opts); err != nil {
 					opts.Logger.Fatal(err)
 				}
 			}


### PR DESCRIPTION
## Description

This PR fixes three issues.

- Recursive fetching of SBOMs was not occurring be unless an output file was specified
- The recursive output files had an exta "." in the name
- When recursive fetching and a output file was specified, the recursive output files were empty

Fixes #133 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran ...
```
bomctl fetch https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/bomctl_bomctl_v0.3.0.cdx.json
```
... with and without an output file.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
