### PR TITLE
refactor: one-time backend setup in rootCmd.PersistentPreRun

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,53 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+# SPDX-FileName: .github/workflows/commitlint.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+name: Check Pull Request Title
+
+on:
+  pull_request:
+    branches: main
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install commitlint
+        run: go install github.com/conventionalcommit/commitlint@e9a606ce7074ac884ea091765be1651be18356d4 # v0.10.1
+
+      - name: Run commitlint against title of pull request
+        env:
+          PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+        run: commitlint lint <<< "${PULL_REQUEST_TITLE}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,6 +124,9 @@ linters-settings:
     # https://golangci-lint.run/usage/linters/#exhaustive
     default-signifies-exhaustive: true
 
+  funlen:
+    ignore-comments: true
+
   govet:
     enable:
       - fieldalignment

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -72,9 +72,7 @@ func exportCmd() *cobra.Command {
 
 			if outputFile != "" {
 				if len(args) > 1 {
-					opts.Logger.Fatal(
-						"The --output-file option cannot be used when more than one SBOM is provided.",
-					)
+					opts.Logger.Fatal("The --output-file option cannot be used when more than one SBOM is provided.")
 				}
 
 				out, err := os.Create(outputFile.String())

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -42,7 +42,7 @@ var (
 )
 
 func exportCmd() *cobra.Command {
-	exportOpts := &options.ExportOptions{}
+	opts := &options.ExportOptions{}
 	outputFile := outputFileValue("")
 
 	exportCmd := &cobra.Command{
@@ -52,8 +52,8 @@ func exportCmd() *cobra.Command {
 		Long:  "Export stored SBOM(s) to filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
-			exportOpts.Options = backend.Options
-			exportOpts.Logger = backend.Logger.WithPrefix("export")
+			opts.Options = backend.Options
+			opts.Logger = backend.Logger.WithPrefix("export")
 
 			defer backend.CloseClient()
 
@@ -65,31 +65,31 @@ func exportCmd() *cobra.Command {
 
 			format, err := parseFormat(formatString, encoding)
 			if err != nil {
-				exportOpts.Logger.Fatal(err, "format", formatString, "encoding", encoding)
+				opts.Logger.Fatal(err, "format", formatString, "encoding", encoding)
 			}
 
-			exportOpts.Format = format
+			opts.Format = format
 
 			if outputFile != "" {
 				if len(args) > 1 {
-					exportOpts.Logger.Fatal(
+					opts.Logger.Fatal(
 						"The --output-file option cannot be used when more than one SBOM is provided.",
 					)
 				}
 
 				out, err := os.Create(outputFile.String())
 				if err != nil {
-					exportOpts.Logger.Fatal("error creating output file", "outputFile", outputFile)
+					opts.Logger.Fatal("error creating output file", "outputFile", outputFile)
 				}
 
-				exportOpts.OutputFile = out
+				opts.OutputFile = out
 
-				defer exportOpts.OutputFile.Close()
+				defer opts.OutputFile.Close()
 			}
 
 			for _, id := range args {
-				if err := export.Export(id, exportOpts); err != nil {
-					exportOpts.Logger.Fatal(err)
+				if err := export.Export(id, opts); err != nil {
+					opts.Logger.Fatal(err)
 				}
 			}
 		},

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bomctl/bomctl/internal/pkg/export"
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
@@ -51,9 +52,8 @@ func exportCmd() *cobra.Command {
 		Short: "Export stored SBOM(s) to filesystem",
 		Long:  "Export stored SBOM(s) to filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
+			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("export"))
 			backend := backendFromContext(cmd)
-			opts.Options = backend.Options
-			opts.Logger = backend.Logger.WithPrefix("export")
 
 			defer backend.CloseClient()
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -45,9 +45,7 @@ func fetchCmd() *cobra.Command {
 
 			if outputFileName != "" {
 				if len(args) > 1 {
-					opts.Logger.Fatal(
-						"The --output-file option cannot be used when more than one URL is provided.",
-					)
+					opts.Logger.Fatal("The --output-file option cannot be used when more than one URL is provided.")
 				}
 
 				out, err := os.Create(string(outputFileName))

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bomctl/bomctl/internal/pkg/fetch"
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
@@ -37,9 +38,8 @@ func fetchCmd() *cobra.Command {
 		Short: "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Long:  "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Run: func(cmd *cobra.Command, args []string) {
+			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("fetch"))
 			backend := backendFromContext(cmd)
-			opts.Options = backend.Options
-			opts.Logger = backend.Logger.WithPrefix("fetch")
 
 			defer backend.CloseClient()
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	imprt "github.com/bomctl/bomctl/internal/pkg/import"
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
@@ -37,9 +38,8 @@ func importCmd() *cobra.Command {
 		Short: "Import SBOM file(s) from stdin or local filesystem",
 		Long:  "Import SBOM file(s) from stdin or local filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
+			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("import"))
 			backend := backendFromContext(cmd)
-			opts.Options = backend.Options
-			opts.Logger = backend.Logger.WithPrefix("import")
 
 			defer backend.CloseClient()
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -29,7 +29,7 @@ import (
 )
 
 func importCmd() *cobra.Command {
-	importOpts := &options.ImportOptions{}
+	opts := &options.ImportOptions{}
 
 	importCmd := &cobra.Command{
 		Use:   "import [flags] { - | FILE...}",
@@ -38,32 +38,32 @@ func importCmd() *cobra.Command {
 		Long:  "Import SBOM file(s) from stdin or local filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
-			importOpts.Options = backend.Options
-			importOpts.Logger = backend.Logger.WithPrefix("import")
+			opts.Options = backend.Options
+			opts.Logger = backend.Logger.WithPrefix("import")
 
 			defer backend.CloseClient()
 
 			if slices.Contains(args, "-") && len(args) > 1 {
-				importOpts.Logger.Fatal("Piped input and file path args cannot be specified simultaneously.")
+				opts.Logger.Fatal("Piped input and file path args cannot be specified simultaneously.")
 			}
 
 			for idx := range args {
 				if args[idx] == "-" {
-					importOpts.InputFiles = append(importOpts.InputFiles, os.Stdin)
+					opts.InputFiles = append(opts.InputFiles, os.Stdin)
 				} else {
 					file, err := os.Open(args[idx])
 					if err != nil {
-						importOpts.Logger.Fatal("failed to open input file", "err", err, "file", file)
+						opts.Logger.Fatal("failed to open input file", "err", err, "file", file)
 					}
 
-					importOpts.InputFiles = append(importOpts.InputFiles, file)
+					opts.InputFiles = append(opts.InputFiles, file)
 
 					defer file.Close() //nolint:revive
 				}
 			}
 
-			if err := imprt.Import(importOpts); err != nil {
-				importOpts.Logger.Fatal(err)
+			if err := imprt.Import(opts); err != nil {
+				opts.Logger.Fatal(err)
 			}
 		},
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -52,7 +52,7 @@ func listCmd() *cobra.Command {
 		Long:    "List SBOM documents in local cache",
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
-			backend.Logger = backend.Logger.WithPrefix("list")
+			backend.Logger.SetPrefix("list")
 
 			defer backend.CloseClient()
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -22,6 +22,7 @@ import (
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/spf13/cobra"
 
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 	"github.com/bomctl/bomctl/internal/pkg/push"
 )
@@ -37,9 +38,8 @@ func pushCmd() *cobra.Command {
 		Short: "Push stored SBOM file to remote URL or filesystem",
 		Long:  "Push stored SBOM file to remote URL or filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
+			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("push"))
 			backend := backendFromContext(cmd)
-			opts.Options = backend.Options
-			opts.Logger = backend.Logger.WithPrefix("fetch")
 
 			defer backend.CloseClient()
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -24,23 +24,25 @@ import (
 
 	"github.com/bomctl/bomctl/internal/pkg/options"
 	"github.com/bomctl/bomctl/internal/pkg/push"
-	"github.com/bomctl/bomctl/internal/pkg/utils"
 )
 
 const pushArgNum = 2
 
 func pushCmd() *cobra.Command {
-	opts := &options.PushOptions{
-		Options: options.New(options.WithLogger(utils.NewLogger("push"))),
-	}
+	opts := &options.PushOptions{}
 
 	pushCmd := &cobra.Command{
-		Use:    "push [flags] SBOM_ID DEST_PATH",
-		Args:   cobra.MinimumNArgs(pushArgNum),
-		Short:  "Push stored SBOM file to remote URL or filesystem",
-		Long:   "Push stored SBOM file to remote URL or filesystem",
-		PreRun: preRun(opts.Options),
+		Use:   "push [flags] SBOM_ID DEST_PATH",
+		Args:  cobra.MinimumNArgs(pushArgNum),
+		Short: "Push stored SBOM file to remote URL or filesystem",
+		Long:  "Push stored SBOM file to remote URL or filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
+			backend := backendFromContext(cmd)
+			opts.Options = backend.Options
+			opts.Logger = backend.Logger.WithPrefix("fetch")
+
+			defer backend.CloseClient()
+
 			formatString, err := cmd.Flags().GetString("format")
 			cobra.CheckErr(err)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,86 +28,110 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/bomctl/bomctl/internal/pkg/db"
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
 const (
-	minDebugLevel        = 2
-	readWriteExecuteUser = 0o700
+	modeUserRead  = 0o400
+	modeUserWrite = 0o200
+	modeUserExec  = 0o100
 )
+
+func backendFromContext(cmd *cobra.Command) *db.Backend {
+	backend, err := db.BackendFromContext(cmd.Context())
+	if err != nil {
+		logger.New("").Fatal(err)
+	}
+
+	return backend
+}
+
+func defaultCacheDir() string {
+	cacheDir, err := os.UserCacheDir()
+	cobra.CheckErr(err)
+
+	return filepath.Join(cacheDir, "bomctl")
+}
+
+func defaultConfig() string {
+	cfgDir, err := os.UserConfigDir()
+	cobra.CheckErr(err)
+
+	return filepath.Join(cfgDir, "bomctl", "bomctl.yaml")
+}
 
 func initCache() {
 	cacheDir := viper.GetString("cache_dir")
-
-	if cache, err := os.UserCacheDir(); cacheDir == "" && err == nil {
-		cacheDir = filepath.Join(cache, "bomctl")
-		viper.Set("cache_dir", cacheDir)
-	}
-
-	cobra.CheckErr(os.MkdirAll(cacheDir, os.FileMode(readWriteExecuteUser)))
+	cobra.CheckErr(os.MkdirAll(cacheDir, modeUserRead|modeUserWrite|modeUserExec))
 }
 
-func initConfig() {
-	cfgFile := viper.GetString("config_file")
+func initConfig(cmd *cobra.Command) func() {
+	return func() {
+		cfgFile := cmd.PersistentFlags().Lookup("config").Value.String()
 
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		cfgDir, err := os.UserConfigDir()
-		cobra.CheckErr(err)
+		if cfgFile != "" {
+			viper.SetConfigFile(cfgFile)
+		} else {
+			cfgDir, err := os.UserConfigDir()
+			cobra.CheckErr(err)
 
-		cfgDir = filepath.Join(cfgDir, "bomctl")
-		cobra.CheckErr(os.MkdirAll(cfgDir, os.FileMode(readWriteExecuteUser)))
+			cfgDir = filepath.Join(cfgDir, "bomctl")
+			cobra.CheckErr(os.MkdirAll(cfgDir, modeUserRead|modeUserWrite|modeUserExec))
 
-		viper.AddConfigPath(cfgDir)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("bomctl")
+			viper.AddConfigPath(cfgDir)
+			viper.SetConfigType("yaml")
+			viper.SetConfigName("bomctl")
+		}
+
+		viper.SetEnvPrefix("bomctl")
+		viper.AutomaticEnv()
+
+		if err := viper.ReadInConfig(); err == nil {
+			fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		}
+
+		cobra.CheckErr(os.MkdirAll(viper.GetString("cache_dir"), modeUserRead|modeUserWrite|modeUserExec))
 	}
-
-	viper.SetEnvPrefix("bomctl")
-	viper.AutomaticEnv()
-
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-
-	cobra.CheckErr(os.MkdirAll(viper.GetString("cache_dir"), os.FileMode(readWriteExecuteUser)))
 }
 
 func rootCmd() *cobra.Command {
-	cobra.OnInitialize(initCache, initConfig)
-
 	rootCmd := &cobra.Command{
 		Use:     "bomctl",
 		Long:    "Simpler Software Bill of Materials management",
-		Version: Version,
+		Version: VersionString,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			verbosity, err := cmd.Flags().GetCount("verbose")
 			cobra.CheckErr(err)
 
+			opts := options.New().
+				WithCacheDir(viper.GetString("cache_dir")).
+				WithConfigFile(viper.ConfigFileUsed()).
+				WithVerbosity(verbosity)
+
 			if verbosity > 0 {
-				log.SetLevel(log.DebugLevel)
+				opts.Logger.SetLevel(log.DebugLevel)
 			}
+
+			backend, err := db.NewBackend(
+				db.WithDatabaseFile(filepath.Join(opts.CacheDir, db.DatabaseFile)),
+				db.WithOptions(opts),
+			)
+			if err != nil {
+				opts.Logger.Fatalf("%v", err)
+			}
+
+			cmd.SetContext(context.WithValue(cmd.Context(), db.BackendKey{}, backend))
+			opts.WithContext(cmd.Context())
 		},
 	}
 
-	rootCmd.PersistentFlags().String("cache-dir", "",
-		fmt.Sprintf("cache directory [defaults:\n\t%s\n\t%s\n\t%s",
-			"Unix:    $HOME/.cache/bomctl",
-			"Darwin:  $HOME/Library/Caches/bomctl",
-			"Windows: %LocalAppData%\\bomctl]",
-		),
-	)
-
-	rootCmd.PersistentFlags().String("config", "",
-		fmt.Sprintf("config file [defaults:\n\t%s\n\t%s\n\t%s",
-			"Unix:    $HOME/.config/bomctl/bomctl.yaml",
-			"Darwin:  $HOME/Library/Application Support/bomctl/bomctl.yml",
-			"Windows: %AppData%\\bomctl\\bomctl.yml]",
-		),
-	)
-
+	rootCmd.PersistentFlags().String("cache-dir", defaultCacheDir(), "cache directory")
+	rootCmd.PersistentFlags().String("config", defaultConfig(), "config file")
 	rootCmd.PersistentFlags().CountP("verbose", "v", "Enable debug output")
+
+	cobra.OnInitialize(initCache, initConfig(rootCmd))
 
 	// Bind flags to their associated viper configurations.
 	cobra.CheckErr(viper.BindPFlag("cache_dir", rootCmd.PersistentFlags().Lookup("cache-dir")))
@@ -119,21 +144,6 @@ func rootCmd() *cobra.Command {
 	rootCmd.AddCommand(versionCmd())
 
 	return rootCmd
-}
-
-func preRun(opts *options.Options) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, _ []string) {
-		cfgFile, err := cmd.Flags().GetString("config")
-		cobra.CheckErr(err)
-
-		verbosity, err := cmd.Flags().GetCount("verbose")
-		cobra.CheckErr(err)
-
-		opts.
-			WithCacheDir(viper.GetString("cache_dir")).
-			WithConfigFile(cfgFile).
-			WithDebug(verbosity >= minDebugLevel)
-	}
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,6 +116,10 @@ func rootCmd() *cobra.Command {
 			verbosity, err := cmd.Flags().GetCount("verbose")
 			cobra.CheckErr(err)
 
+			if verbosity > 0 {
+				log.SetLevel(log.DebugLevel)
+			}
+
 			cacheDir, err := cmd.Flags().GetString("cache-dir")
 			cobra.CheckErr(err)
 
@@ -123,10 +127,6 @@ func rootCmd() *cobra.Command {
 				WithCacheDir(cacheDir).
 				WithConfigFile(viper.ConfigFileUsed()).
 				WithVerbosity(verbosity)
-
-			if verbosity > 0 {
-				opts.Logger.SetLevel(log.DebugLevel)
-			}
 
 			backend, err := db.NewBackend(
 				db.WithDatabaseFile(filepath.Join(cacheDir, db.DatabaseFile)),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,12 +22,17 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 )
 
 //nolint:gochecknoglobals
 var (
 	// BuildDate is the date and time this binary was built.
 	BuildDate string
+
+	// Version is the full version string.
+	Version = fmt.Sprintf("v%s.%s.%s%s", VersionMajor, VersionMinor, VersionPatch, VersionPre)
 
 	// VersionMajor is for breaking API changes.
 	VersionMajor string
@@ -41,14 +46,8 @@ var (
 	// VersionPre indicates prerelease branch.
 	VersionPre string
 
-	// Version is the specification version that the package types support.
-	Version = fmt.Sprintf("v%s.%s.%s%s (built on %s)",
-		VersionMajor,
-		VersionMinor,
-		VersionPatch,
-		VersionPre,
-		BuildDate,
-	)
+	// VersionString is the specification version that the package types support.
+	VersionString = fmt.Sprintf("%s (built on %s)", Version, BuildDate)
 )
 
 func versionCmd() *cobra.Command {
@@ -57,7 +56,7 @@ func versionCmd() *cobra.Command {
 		Short: "Show version",
 		Long:  "Print the version",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println("bomctl version", Version) //nolint:forbidigo // Print to terminal and exit
+			logger.New("bomctl").Print("", "version", Version, "buildDate", BuildDate)
 		},
 	}
 

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -31,14 +31,12 @@ import (
 
 var errUnsupportedURL = errors.New("failed to parse URL; see `--help` for valid URL patterns")
 
-type (
-	Client interface {
-		url.Parser
-		Name() string
-		Fetch(string, *options.FetchOptions) ([]byte, error)
-		Push(string, string, *options.PushOptions) error
-	}
-)
+type Client interface {
+	url.Parser
+	Name() string
+	Fetch(string, *options.FetchOptions) ([]byte, error)
+	Push(string, string, *options.PushOptions) error
+}
 
 func New(sbomURL string) (Client, error) {
 	for _, client := range []Client{&git.Client{}, &http.Client{}, &oci.Client{}} {

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -19,16 +19,21 @@
 package db
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
-	"github.com/charmbracelet/log"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/protobom/storage/backends/ent"
 
+	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-const DatabaseFile string = "bomctl.db"
+const (
+	DatabaseFile  string = "bomctl.db"
+	EntDebugLevel int    = 2
+)
 
 type (
 	Backend struct {
@@ -36,17 +41,40 @@ type (
 		*options.Options
 	}
 
+	BackendKey struct{}
+
 	Option func(*Backend)
 )
+
+var errBackendMissingFromContext = errors.New("failed to get database backend from command context")
+
+func BackendFromContext(ctx context.Context) (*Backend, error) {
+	backend, ok := ctx.Value(BackendKey{}).(*Backend)
+	if !ok {
+		return nil, errBackendMissingFromContext
+	}
+
+	return backend, nil
+}
 
 func NewBackend(opts ...Option) (*Backend, error) {
 	backend := &Backend{
 		Backend: ent.NewBackend(),
-		Options: options.New(),
+		Options: options.New(
+			options.WithLogger(logger.New("db")),
+		),
 	}
 
 	for _, opt := range opts {
 		opt(backend)
+	}
+
+	if backend.Verbosity >= EntDebugLevel {
+		backend.Backend.Debug()
+	}
+
+	if backend.Backend.Options.DatabaseFile == "" {
+		backend.Backend.Options.DatabaseFile = DatabaseFile
 	}
 
 	if err := backend.InitClient(); err != nil {
@@ -77,37 +105,16 @@ func (backend *Backend) GetDocumentByID(id string) (*sbom.Document, error) {
 	return document, nil
 }
 
-// WithOptions sets the options for the backend.
-func (backend *Backend) WithOptions(opts *options.Options) *Backend {
-	backend.Options = opts
-
-	return backend
-}
-
-// WithLogger sets the logger for the backend.
-func (backend *Backend) WithLogger(logger *log.Logger) *Backend {
-	backend.Logger = logger
-
-	return backend
+// WithDatabaseFile sets the database file for the backend.
+func WithDatabaseFile(file string) Option {
+	return func(backend *Backend) {
+		backend.Backend.Options.DatabaseFile = file
+	}
 }
 
 // WithOptions sets the options for the backend.
 func WithOptions(opts *options.Options) Option {
 	return func(backend *Backend) {
-		backend.WithOptions(opts)
-	}
-}
-
-// Debug enables debug logging for all database transactions.
-func Debug(debug bool) Option {
-	return func(backend *Backend) {
-		backend.Options.Debug = debug
-	}
-}
-
-// WithDatabaseFile sets the database file for the backend.
-func WithDatabaseFile(file string) Option {
-	return func(backend *Backend) {
-		backend.Backend.Options.DatabaseFile = file
+		backend.Options = opts
 	}
 }

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -23,11 +23,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/charmbracelet/log"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/protobom/storage/backends/ent"
 
 	"github.com/bomctl/bomctl/internal/pkg/logger"
-	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
 const (
@@ -38,7 +38,8 @@ const (
 type (
 	Backend struct {
 		*ent.Backend
-		*options.Options
+		*log.Logger
+		Verbosity int
 	}
 
 	BackendKey struct{}
@@ -58,12 +59,7 @@ func BackendFromContext(ctx context.Context) (*Backend, error) {
 }
 
 func NewBackend(opts ...Option) (*Backend, error) {
-	backend := &Backend{
-		Backend: ent.NewBackend(),
-		Options: options.New(
-			options.WithLogger(logger.New("db")),
-		),
-	}
+	backend := &Backend{Backend: ent.NewBackend(), Logger: logger.New("db")}
 
 	for _, opt := range opts {
 		opt(backend)
@@ -112,9 +108,9 @@ func WithDatabaseFile(file string) Option {
 	}
 }
 
-// WithOptions sets the options for the backend.
-func WithOptions(opts *options.Options) Option {
+// WithVerbosity sets the SQL debugging level for the backend.
+func WithVerbosity(verbosity int) Option {
 	return func(backend *Backend) {
-		backend.Options = opts
+		backend.Verbosity = verbosity
 	}
 }

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -55,12 +55,10 @@ func (dbs *dbSuite) SetupSuite() {
 		dbs.documents = append(dbs.documents, doc)
 	}
 
-	dbs.backend, err = db.NewBackend()
+	dbs.backend, err = db.NewBackend(db.WithDatabaseFile(db.DatabaseFile))
 	if err != nil {
 		dbs.T().Fatalf("%v", err)
 	}
-
-	dbs.backend.Backend.Options.DatabaseFile = db.DatabaseFile
 }
 
 func (dbs *dbSuite) TearDownSuite() {

--- a/internal/pkg/export/export.go
+++ b/internal/pkg/export/export.go
@@ -21,33 +21,20 @@ package export
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/writer"
-	"github.com/spf13/viper"
 
 	"github.com/bomctl/bomctl/internal/pkg/db"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-type Options struct {
-	*options.Options
-	OutputFile *os.File
-	Format     formats.Format
-}
-
-func Export(sbomID string, opts *Options) error {
-	opts.Logger.Info("Exporting Document", "sbomID", sbomID)
-
-	backend, err := db.NewBackend(
-		db.WithDatabaseFile(filepath.Join(viper.GetString("cache_dir"), db.DatabaseFile)),
-		db.WithOptions(opts.Options))
+func Export(sbomID string, opts *options.ExportOptions) error {
+	backend, err := db.BackendFromContext(opts.Context())
 	if err != nil {
-		return fmt.Errorf("failed to initialize backend client: %w", err)
+		return fmt.Errorf("%w", err)
 	}
 
-	defer backend.CloseClient()
+	backend.Logger.Info("Exporting document", "sbomID", sbomID)
 
 	wr := writer.New(writer.WithFormat(opts.Format))
 

--- a/internal/pkg/export/export.go
+++ b/internal/pkg/export/export.go
@@ -34,7 +34,7 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 		return fmt.Errorf("%w", err)
 	}
 
-	backend.Logger.Info("Exporting document", "sbomID", sbomID)
+	opts.Logger.Info("Exporting document", "sbomID", sbomID)
 
 	wr := writer.New(writer.WithFormat(opts.Format))
 

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -41,7 +41,7 @@ func Fetch(sbomURL string, opts *options.FetchOptions) error {
 		return fmt.Errorf("%w", err)
 	}
 
-	document, err := fetchDocument(sbomURL, backend, opts)
+	document, err := fetchDocument(sbomURL, opts)
 	if err != nil {
 		return err
 	}
@@ -55,13 +55,13 @@ func Fetch(sbomURL string, opts *options.FetchOptions) error {
 	return fetchExternalReferences(document, backend, opts)
 }
 
-func fetchDocument(sbomURL string, backend *db.Backend, opts *options.FetchOptions) (*sbom.Document, error) {
+func fetchDocument(sbomURL string, opts *options.FetchOptions) (*sbom.Document, error) {
 	fetcher, err := client.New(sbomURL)
 	if err != nil {
 		return nil, fmt.Errorf("creating fetch client: %w", err)
 	}
 
-	backend.Logger.Info(fmt.Sprintf("Fetching from %s URL", fetcher.Name()), "url", sbomURL)
+	opts.Logger.Info(fmt.Sprintf("Fetching from %s URL", fetcher.Name()), "url", sbomURL)
 
 	sbomData, err := fetcher.Fetch(sbomURL, opts)
 	if err != nil {

--- a/internal/pkg/import/import.go
+++ b/internal/pkg/import/import.go
@@ -22,30 +22,18 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/protobom/protobom/pkg/reader"
-	"github.com/spf13/viper"
 
 	"github.com/bomctl/bomctl/internal/pkg/db"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-type ImportOptions struct {
-	*options.Options
-	InputFiles []*os.File
-}
-
-func Import(opts *ImportOptions) error {
-	backend, err := db.NewBackend(
-		db.WithDatabaseFile(filepath.Join(viper.GetString("cache_dir"), db.DatabaseFile)),
-		db.WithOptions(opts.Options))
+func Import(opts *options.ImportOptions) error {
+	backend, err := db.BackendFromContext(opts.Context())
 	if err != nil {
-		return fmt.Errorf("failed to initialize backend client: %w", err)
+		return fmt.Errorf("%w", err)
 	}
-
-	defer backend.CloseClient()
 
 	sbomReader := reader.New()
 

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -16,7 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ------------------------------------------------------------------------
-package utils
+package logger
 
 import (
 	"os"
@@ -26,7 +26,7 @@ import (
 
 const levelWidth = 5
 
-func NewLogger(prefix string) *log.Logger {
+func New(prefix string) *log.Logger {
 	// Set displayed width of log level in messages to show full level name
 	styles := log.DefaultStyles()
 	for _, level := range []log.Level{log.DebugLevel, log.ErrorLevel, log.FatalLevel, log.InfoLevel, log.WarnLevel} {


### PR DESCRIPTION
## Description

This PR refactors the initialization of the ent backend to occur one time during `rootCmd.PersistentPreRun` and pass the backend to sub commands in a context.

## Type of change

- [X] Refactor

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings