### PR TITLE
refactor: dynamic prefix for subcommand loggers

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -33,7 +33,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bomctl/bomctl/internal/pkg/export"
-	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
@@ -52,7 +51,7 @@ func exportCmd() *cobra.Command {
 		Short: "Export stored SBOM(s) to filesystem",
 		Long:  "Export stored SBOM(s) to filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
-			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("export"))
+			opts.Options = optionsFromContext(cmd)
 			backend := backendFromContext(cmd)
 
 			defer backend.CloseClient()

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bomctl/bomctl/internal/pkg/fetch"
-	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
@@ -38,7 +37,7 @@ func fetchCmd() *cobra.Command {
 		Short: "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Long:  "Fetch SBOM file(s) from HTTP(S), OCI, or Git URLs",
 		Run: func(cmd *cobra.Command, args []string) {
-			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("fetch"))
+			opts.Options = optionsFromContext(cmd)
 			backend := backendFromContext(cmd)
 
 			defer backend.CloseClient()

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	imprt "github.com/bomctl/bomctl/internal/pkg/import"
-	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
@@ -38,7 +37,7 @@ func importCmd() *cobra.Command {
 		Short: "Import SBOM file(s) from stdin or local filesystem",
 		Long:  "Import SBOM file(s) from stdin or local filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
-			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("import"))
+			opts.Options = optionsFromContext(cmd)
 			backend := backendFromContext(cmd)
 
 			defer backend.CloseClient()

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -22,7 +22,6 @@ import (
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/spf13/cobra"
 
-	"github.com/bomctl/bomctl/internal/pkg/logger"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 	"github.com/bomctl/bomctl/internal/pkg/push"
 )
@@ -38,7 +37,7 @@ func pushCmd() *cobra.Command {
 		Short: "Push stored SBOM file to remote URL or filesystem",
 		Long:  "Push stored SBOM file to remote URL or filesystem",
 		Run: func(cmd *cobra.Command, args []string) {
-			opts.Options = optionsFromContext(cmd).WithLogger(logger.New("push"))
+			opts.Options = optionsFromContext(cmd)
 			backend := backendFromContext(cmd)
 
 			defer backend.CloseClient()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,10 +123,17 @@ func rootCmd() *cobra.Command {
 			cacheDir, err := cmd.Flags().GetString("cache-dir")
 			cobra.CheckErr(err)
 
+			// Get first top-level subcommand.
+			subcmd := cmd
+			for subcmd.HasParent() && subcmd.Parent() != subcmd.Root() {
+				subcmd = subcmd.Parent()
+			}
+
 			opts := options.New().
 				WithCacheDir(cacheDir).
 				WithConfigFile(viper.ConfigFileUsed()).
-				WithVerbosity(verbosity)
+				WithVerbosity(verbosity).
+				WithLogger(logger.New(subcmd.Name()))
 
 			backend, err := db.NewBackend(
 				db.WithDatabaseFile(filepath.Join(cacheDir, db.DatabaseFile)),


### PR DESCRIPTION
## Description

This PR includes a small refactor to use a dynamic prefix when creating a subcommand's logger, and only call the logger instantiation from a single location in `rootCmd` instead of from every subcommand.

The intent is to use the first top-level subcommand's name in cases where a subcommand may have more than one nested subcommand (e.g. `bomctl alias remove ...`, in which case the logger prefix will be `alias:` instead of `remove:`).

## Type of change

- [X] Refactor

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings