### PR TITLE
chore: add Taskfile.yml as alternative to make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 !/docs/**/*.md
 !/docs/images/*.png
 !/docs/images/*.svg
+!/Taskfile.yml
 
 # Whitelist patterns found anywhere in project
 !.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !/.markdownlint.yml
 !/.markdownlintignore
 !/.pre-commit-config.yaml
+!/.taskfiles/*.yml
 !/.vscode/adr.code-snippets
 !/.vscode/extensions.json
 !/.vscode/header.code-snippets

--- a/.taskfiles/build.yml
+++ b/.taskfiles/build.yml
@@ -1,0 +1,108 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+# SPDX-FileName: .taskfiles/build.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+
+env:
+  GO111MODULE: "on"
+  GOPATH:
+    sh: go env GOPATH
+  GOPROXY: https://proxy.golang.org,direct
+  LDFLAGS: -s -w
+    -X=github.com/bomctl/bomctl/cmd.VersionMajor={{.VERSION_MAJOR}}
+    -X=github.com/bomctl/bomctl/cmd.VersionMinor={{.VERSION_MINOR}}
+    -X=github.com/bomctl/bomctl/cmd.VersionPatch={{.VERSION_PATCH}}
+    -X=github.com/bomctl/bomctl/cmd.VersionPre={{.VERSION_PRE}}
+    -X=github.com/bomctl/bomctl/cmd.BuildDate={{.BUILD_DATE}}
+
+vars:
+  BUILD_DATE: '{{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}'
+  GIT_SHA:
+    sh: git rev-parse HEAD
+  VERSION:
+    sh: '{{default "Undefined" "git describe --tags --abbrev=0"}}'
+  VERSION_REGEX: v(\d+)\.(\d+)\.(\d+)
+  VERSION_MAJOR: '{{regexReplaceAll .VERSION_REGEX .VERSION "${1}"}}'
+  VERSION_MINOR: '{{regexReplaceAll .VERSION_REGEX .VERSION "${2}"}}'
+  VERSION_PATCH: '{{regexReplaceAll .VERSION_REGEX .VERSION "${3}"}}'
+
+tasks:
+  gobuild:
+    internal: true
+    generates:
+      - "{{.OUTPUT}}"
+    env:
+      CGO_ENABLED: 0
+      GOOS: "{{.GOOS}}"
+      GOARCH: "{{.GOARCH}}"
+    vars:
+      OUTPUT: '{{joinPath "dist" (list .GOOS .GOARCH | join "-") "bomctl"}}{{.EXT}}'
+    cmd: go build -trimpath -o {{.OUTPUT}} -ldflags="${LDFLAGS}"
+
+  linux:amd:
+    desc: Build for Linux on AMD64
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: linux
+        GOARCH: amd64
+
+  linux:arm:
+    desc: Build for Linux on ARM
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: linux
+        GOARCH: arm64
+
+  macos:intel:
+    desc: Build for macOS on AMD64
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: darwin
+        GOARCH: amd64
+
+  macos:apple:
+    desc: Build for macOS on ARM
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: darwin
+        GOARCH: arm64
+
+  windows:amd:
+    desc: Build for Windows on AMD64
+    cmd:
+      task: gobuild
+      vars:
+        EXT: .exe
+        GOOS: windows
+        GOARCH: amd64
+
+  windows:arm:
+    desc: Build for Windows on ARM
+    cmd:
+      task: gobuild
+      vars:
+        EXT: .exe
+        GOOS: windows
+        GOARCH: arm64

--- a/.taskfiles/fix.yml
+++ b/.taskfiles/fix.yml
@@ -1,0 +1,52 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+# SPDX-FileName: .taskfiles/fix.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+
+includes:
+  lint:
+    internal: true
+    taskfile: lint.yml
+
+tasks:
+  go:
+    desc: Fix golangci-lint findings
+    cmd:
+      task: lint:run
+      vars:
+        CLI_NAME: golangci-lint{{exeExt}}
+        CLI_ARGS: [run, --fix, --verbose]
+
+  markdown:
+    desc: Fix markdown lint findings
+    cmd:
+      task: lint:run
+      vars:
+        CLI_NAME: markdownlint-cli2
+        CLI_ARGS: [--fix, "{{catLines .MARKDOWN_FILES}}"]
+
+  shell:
+    desc: Fix shell script lint findings
+    cmd:
+      task: lint:run
+      vars:
+        CLI_NAME: shfmt{{exeExt}}
+        CLI_ARGS: [--write, --simplify, "{{catLines .SHELL_FILES}}"]

--- a/.taskfiles/install.yml
+++ b/.taskfiles/install.yml
@@ -1,0 +1,106 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+# SPDX-FileName: .taskfiles/install.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+
+vars:
+  GOLANGCI_LINT_VERSION: v1.60.3
+  GOLANGCI_LINT_RELEASE_URL: https://github.com/golangci/golangci-lint/releases/download/{{.GOLANGCI_LINT_VERSION}}
+  SHELLCHECK_ARCH: '{{eq ARCH "amd64" | ternary "x86_64" "aarch64"}}'
+  SHELLCHECK_VERSION: v0.10.0
+  SHELLCHECK_RELEASE_URL: https://github.com/koalaman/shellcheck/releases/download/{{.SHELLCHECK_VERSION}}
+  SHFMT_VERSION: v3.9.0
+
+tasks:
+  make-tools-dir:
+    silent: true
+    status:
+      - test -d {{.TOOLS_DIR}}
+    cmds:
+      - cmd: mkdir {{.TOOLS_DIR}}
+        platforms: [darwin, linux]
+
+      - cmd: powershell -Command '$null = New-Item -ItemType directory -Path {{shellQuote .TOOLS_DIR}}'
+        platforms: [windows]
+
+  unzip-windows:
+    internal: true
+    platforms: [windows]
+    cmd: powershell -Command 'Add-Type -Assembly System.IO.Compression.FileSystem;
+      $zip = [IO.Compression.ZipFile]::OpenRead("{{.ZIP_FILENAME}}");
+      $entry = $zip.Entries | Where-Object -Property Name -EQ "{{.EXE_FILENAME}}";
+      $target = {{shellQuote (joinPath .TOOLS_DIR .EXE_FILENAME)}};
+      [IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target)'
+
+  golangci-lint:
+    desc: Install golangci-lint
+    vars:
+      GOLANGCI_LINT_PREFIX: golangci-lint-{{trimPrefix "v" .GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}
+      GOLANGCI_LINT_FILENAME: '{{.GOLANGCI_LINT_PREFIX}}{{if eq OS "windows"}}.zip{{else}}.tar.gz{{end}}'
+      GOLANGCI_LINT_DOWNLOAD_URL: "{{.GOLANGCI_LINT_RELEASE_URL}}/{{.GOLANGCI_LINT_FILENAME}}"
+    status:
+      - test -x "{{shellQuote .TOOLS_DIR}}/golangci-lint{{exeExt}}"
+    cmds:
+      - task: make-tools-dir
+      - cmd: curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
+      - defer: "{{.RM}} {{.GOLANGCI_LINT_FILENAME}}"
+      - cmd: tar --extract --gzip --file {{.GOLANGCI_LINT_FILENAME}} --directory {{.TOOLS_DIR}}
+          --strip-components=1 {{.GOLANGCI_LINT_PREFIX}}/golangci-lint
+        platforms: [darwin, linux]
+      - task: unzip-windows
+        vars:
+          ZIP_FILENAME: "{{.GOLANGCI_LINT_FILENAME}}"
+          EXE_FILENAME: golangci-lint.exe
+
+  shellcheck:
+    desc: Install shellcheck
+    vars:
+      SHELLCHECK_PREFIX: shellcheck-{{.SHELLCHECK_VERSION}}
+      SHELLCHECK_EXTENSION: '{{if eq OS "windows"}}.zip{{else}}.{{OS}}.{{.SHELLCHECK_ARCH}}.tar.xz{{end}}'
+      SHELLCHECK_FILENAME: "{{.SHELLCHECK_PREFIX}}{{.SHELLCHECK_EXTENSION}}"
+      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
+    status:
+      - test -x "{{shellQuote .TOOLS_DIR}}/shellcheck{{exeExt}}"
+    cmds:
+      - task: make-tools-dir
+      - cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
+      - defer: "{{.RM}} {{.SHELLCHECK_FILENAME}}"
+      - cmd: tar --extract --xz --file {{.SHELLCHECK_FILENAME}} --directory {{.TOOLS_DIR}}
+          --strip-components=1 {{.SHELLCHECK_PREFIX}}/shellcheck
+        platforms: [darwin, linux]
+      - task: unzip-windows
+        vars:
+          ZIP_FILENAME: "{{.SHELLCHECK_FILENAME}}"
+          EXE_FILENAME: shellcheck.exe
+
+  shfmt:
+    desc: Install shfmt
+    vars:
+      SHFMT_FILENAME: shfmt_{{.SHFMT_VERSION}}_{{OS}}_{{ARCH}}{{exeExt}}
+      SHFMT_DOWNLOAD_URL: https://github.com/mvdan/sh/releases/download/{{.SHFMT_VERSION}}/{{.SHFMT_FILENAME}}
+    status:
+      - test -x "{{shellQuote .TOOLS_DIR}}/shfmt{{exeExt}}"
+    cmds:
+      - task: make-tools-dir
+      - cmd: curl --fail --silent --show-error --location
+          --url {{.SHFMT_DOWNLOAD_URL}}
+          --output {{.TOOLS_DIR}}/shfmt{{exeExt}}
+      - cmd: '{{if ne OS "windows"}}chmod +x {{.TOOLS_DIR}}/shfmt{{end}}'

--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -1,0 +1,80 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+# SPDX-FileName: .taskfiles/lint.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+
+env:
+  BOLD: \033[1m
+  CYAN: \033[36m
+  YELLOW: \033[33m
+  RESET: \033[0m
+
+tasks:
+  run:
+    silent: true
+    dir: "{{.ROOT_DIR}}"
+    vars:
+      CLI_ARGS: '{{.CLI_ARGS | join " "}}'
+    cmd: >
+      export PATH="{{shellQuote .TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}{{env "PATH"}}";
+      if command -v {{.CLI_NAME}} > /dev/null; then
+        printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n";
+        {{.CLI_NAME}} {{.CLI_ARGS}};
+      else
+        printf "${YELLOW}{{.CLI_NAME}} not found, please install and run the command again.${RESET}\n";
+      fi
+
+  go:
+    desc: Lint Golang code files
+    cmd:
+      task: run
+      vars:
+        CLI_NAME: golangci-lint{{exeExt}}
+        CLI_ARGS: [run, --verbose]
+
+  markdown:
+    desc: Lint markdown files
+    cmd:
+      task: run
+      vars:
+        CLI_NAME: markdownlint-cli2
+        CLI_ARGS: "{{catLines .MARKDOWN_FILES}}"
+
+  shell:
+    desc: Lint shell scripts
+    cmds:
+      - task: run
+        vars:
+          CLI_NAME: shellcheck{{exeExt}}
+          CLI_ARGS: ["{{catLines .SHELL_FILES}}"]
+
+      - task: run
+        vars:
+          CLI_NAME: shfmt{{exeExt}}
+          CLI_ARGS: [--diff, --simplify, "{{catLines .SHELL_FILES}}"]
+
+  yaml:
+    desc: Lint YAML files
+    cmd:
+      task: run
+      vars:
+        CLI_NAME: yamllint
+        CLI_ARGS: ["{{catLines .YAML_FILES}}"]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -20,6 +20,7 @@
     "mtxr.sqltools",
     "redhat.vscode-xml",
     "redhat.vscode-yaml",
+    "task.vscode-task",
     "timonwong.shellcheck",
     "usernamehw.errorlens",
     "VisualStudioExptTeam.vscodeintellicode",

--- a/README.md
+++ b/README.md
@@ -48,27 +48,29 @@ docker run bomctl/bomctl:latest --help
 
 To install bomctl, you need the following:
 
-- [Go](https://go.dev/dl/)
+- [Go](https://go.dev/dl)
 - [Git](https://git-scm.com/downloads)
-- [Make](https://www.gnu.org/software/make/manual/make.html)
+- One of:
+  - [Make](https://www.gnu.org/software/make/manual/make.html)
+  - [Task](https://taskfile.dev)
 
-Clone the bomctl repository
+#### Clone the bomctl repository
 
-``` shell
+```shell
 git clone https://github.com/bomctl/bomctl.git
 cd bomctl
 ```
 
-Build using the `make` command with the `Makefile`
+#### Build using `make` or `task`
 
-| Operating System | Architecture | `make` Command           |
-| ---------------- | ------------ | ------------------------ |
-| Linux            | AMD64        | `make build-linux-amd`   |
-| Linux            | ARM          | `make build-linux-arm`   |
-| Windows          | AMD64        | `make build-windows-amd` |
-| Windows          | ARM          | `make build-windows-arm` |
-| MacOS            | AMD64        | `make build-macos-intel` |
-| MacOS            | ARM          | `make build-macos-apple` |
+| Platform      | `make` Command           | `task` Command           |
+| :------------ | :----------------------- | :----------------------- |
+| linux/amd64   | `make build-linux-amd`   | `task build:linux:amd`   |
+| linux/arm     | `make build-linux-arm`   | `task build:linux:arm`   |
+| windows/amd64 | `make build-windows-amd` | `task build:windows:amd` |
+| windows/arm   | `make build-windows-arm` | `task build:windows:arm` |
+| darwin/amd64  | `make build-macos-intel` | `task build:macos:intel` |
+| darwin/arm    | `make build-macos-apple` | `task build:macos:apple` |
 
 ## Commands
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,8 +75,17 @@ tasks:
       - cmd: mkdir {{.TOOLS_DIR}}
         platforms: [darwin, linux]
 
-      - cmd: powershell -Command "New-Item -ItemType directory -Path {{.TOOLS_DIR}}"
+      - cmd: powershell -Command '$null = New-Item -ItemType directory -Path {{shellQuote .TOOLS_DIR}}'
         platforms: [windows]
+
+  unzip-windows:
+    internal: true
+    platforms: [windows]
+    cmd: powershell -Command 'Add-Type -Assembly System.IO.Compression.FileSystem;
+      $zip = [IO.Compression.ZipFile]::OpenRead("{{.ZIP_FILENAME}}");
+      $entry = $zip.Entries | Where-Object -Property Name -EQ "{{.EXE_FILENAME}}";
+      $target = "{{shellQuote (joinPath .TOOLS_DIR "{{.EXE_FILENAME}}")}}";
+      [IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target)'
 
   install:
     desc: Install dev tools
@@ -92,7 +101,7 @@ tasks:
       GOLANGCI_LINT_FILENAME: '{{.GOLANGCI_LINT_PREFIX}}{{if eq OS "windows"}}.zip{{else}}.tar.gz{{end}}'
       GOLANGCI_LINT_DOWNLOAD_URL: "{{.GOLANGCI_LINT_RELEASE_URL}}/{{.GOLANGCI_LINT_FILENAME}}"
     status:
-      - test -x {{.TOOLS_DIR}}/golangci-lint{{exeExt}}
+      - test -x "{{shellQuote .TOOLS_DIR}}/golangci-lint{{exeExt}}"
     cmds:
       - task: make-tools-dir
       - cmd: curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
@@ -100,8 +109,10 @@ tasks:
       - cmd: tar --extract --gzip --file {{.GOLANGCI_LINT_FILENAME}} --directory {{.TOOLS_DIR}}
           --strip-components=1 {{.GOLANGCI_LINT_PREFIX}}/golangci-lint
         platforms: [darwin, linux]
-      - cmd: unzip -j {{.GOLANGCI_LINT_FILENAME}} {{.GOLANGCI_LINT_PREFIX}}/golangci-lint.exe -d {{.TOOLS_DIR}}
-        platforms: [windows]
+      - task: unzip-windows
+        vars:
+          ZIP_FILENAME: "{{.GOLANGCI_LINT_FILENAME}}"
+          EXE_FILENAME: golangci-lint.exe
 
   install:shellcheck:
     desc: Install shellcheck
@@ -111,7 +122,7 @@ tasks:
       SHELLCHECK_FILENAME: "{{.SHELLCHECK_PREFIX}}{{.SHELLCHECK_EXTENSION}}"
       SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
     status:
-      - test -x {{.TOOLS_DIR}}/shellcheck{{exeExt}}
+      - test -x "{{shellQuote .TOOLS_DIR}}/shellcheck{{exeExt}}"
     cmds:
       - task: make-tools-dir
       - cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
@@ -119,8 +130,10 @@ tasks:
       - cmd: tar --extract --xz --file {{.SHELLCHECK_FILENAME}} --directory {{.TOOLS_DIR}}
           --strip-components=1 {{.SHELLCHECK_PREFIX}}/shellcheck
         platforms: [darwin, linux]
-      - cmd: unzip -j {{.SHELLCHECK_FILENAME}} -d {{.TOOLS_DIR}}
-        platforms: [windows]
+      - task: unzip-windows
+        vars:
+          ZIP_FILENAME: "{{.SHELLCHECK_FILENAME}}"
+          EXE_FILENAME: shellcheck.exe
 
   install:shfmt:
     desc: Install shfmt
@@ -128,7 +141,7 @@ tasks:
       SHFMT_FILENAME: shfmt_{{.SHFMT_VERSION}}_{{OS}}_{{ARCH}}{{exeExt}}
       SHFMT_DOWNLOAD_URL: https://github.com/mvdan/sh/releases/download/{{.SHFMT_VERSION}}/{{.SHFMT_FILENAME}}
     status:
-      - test -x {{.TOOLS_DIR}}/shfmt{{exeExt}}
+      - test -x "{{shellQuote .TOOLS_DIR}}/shfmt{{exeExt}}"
     cmds:
       - task: make-tools-dir
       - cmd: curl --fail --silent --show-error --location
@@ -221,7 +234,7 @@ tasks:
     vars:
       CLI_ARGS: '{{.CLI_ARGS | join " "}}'
     cmd: >
-      export PATH="{{.TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}{{env "PATH"}}";
+      export PATH="{{shellQuote .TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}{{env "PATH"}}";
       if command -v {{.CLI_NAME}} > /dev/null; then
         printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n";
         {{.CLI_NAME}} {{.CLI_ARGS}};

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,292 @@
+# ------------------------------------------------------------------------
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+# SPDX-FileName: Taskfile.yml
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+
+env:
+  GO111MODULE: "on"
+  GOPATH:
+    sh: go env GOPATH
+  GOPROXY: https://proxy.golang.org,direct
+  LDFLAGS: -s -w
+    -X=github.com/bomctl/bomctl/cmd.VersionMajor={{.VERSION_MAJOR}}
+    -X=github.com/bomctl/bomctl/cmd.VersionMinor={{.VERSION_MINOR}}
+    -X=github.com/bomctl/bomctl/cmd.VersionPatch={{.VERSION_PATCH}}
+    -X=github.com/bomctl/bomctl/cmd.VersionPre={{.VERSION_PRE}}
+    -X=github.com/bomctl/bomctl/cmd.BuildDate={{.BUILD_DATE}}
+  BOLD: \033[1m
+  CYAN: \033[36m
+  YELLOW: \033[33m
+  RESET: \033[0m
+
+vars:
+  BUILD_DATE:
+    sh: date -u +'%Y-%m-%dT%H:%M:%SZ'
+  GIT_SHA:
+    sh: git rev-parse HEAD
+  GOLANGCI_LINT_INSTALL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+  GOLANGCI_LINT_VERSION: v1.60.3
+  MARKDOWN_FILES:
+    sh: git ls-files '*.md'
+  SHELL_FILES:
+    sh: git ls-files '*.sh'
+  SHELLCHECK_ARCH: '{{eq ARCH "amd64" | ternary "x86_64" "aarch64"}}'
+  SHELLCHECK_VERSION: v0.10.0
+  SHELLCHECK_RELEASE_URL: https://github.com/koalaman/shellcheck/releases/download/{{.SHELLCHECK_VERSION}}
+  SHFMT_VERSION: v3.9.0
+  TOOLS_DIR: '{{joinPath .ROOT_DIR ".bin"}}'
+  VERSION:
+    sh: '{{default "Undefined" "git describe --tags --abbrev=0"}}'
+  VERSION_REGEX: v(\d+)\.(\d+)\.(\d+)
+  VERSION_MAJOR: '{{regexReplaceAll .VERSION_REGEX .VERSION "${1}"}}'
+  VERSION_MINOR: '{{regexReplaceAll .VERSION_REGEX .VERSION "${2}"}}'
+  VERSION_PATCH: '{{regexReplaceAll .VERSION_REGEX .VERSION "${3}"}}'
+  YAML_FILES:
+    sh: git ls-files '*.yml' '*.yaml'
+
+tasks:
+  # ----------------------------------------------------------------------------
+  # Dev tools tasks
+  # ----------------------------------------------------------------------------
+  install:
+    desc: Install dev tools
+    cmds:
+      - task: install:golangci-lint
+      - task: install:shellcheck:unix
+      - task: install:shellcheck:windows
+      - task: install:shfmt
+
+  install:golangci-lint:
+    desc: Install golangci-lint
+    status:
+      - test -x {{.TOOLS_DIR}}/golangci-lint
+    cmd: curl --fail --silent --show-error --location {{.GOLANGCI_LINT_INSTALL}} |
+      sh -s -- -b {{.TOOLS_DIR}} {{.GOLANGCI_LINT_VERSION}}
+
+  install:shellcheck:unix:
+    desc: Install shellcheck
+    platforms: [darwin, linux]
+    vars:
+      SHELLCHECK_FILENAME: shellcheck-{{.SHELLCHECK_VERSION}}.{{OS}}.{{.SHELLCHECK_ARCH}}.tar.xz
+      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
+    status:
+      - test -x {{.TOOLS_DIR}}/shellcheck
+    cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} |
+      tar --extract --xz --directory {{.TOOLS_DIR}} --strip-components=1 shellcheck-{{.SHELLCHECK_VERSION}}/shellcheck
+
+  install:shellcheck:windows:
+    desc: Install shellcheck
+    platforms: [windows]
+    vars:
+      SHELLCHECK_FILENAME: shellcheck-{{.SHELLCHECK_VERSION}}.zip
+      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
+    status:
+      - test -x {{.TOOLS_DIR}}/shellcheck.exe
+    cmds:
+      - curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --output temp.zip
+      - defer: rm -f temp.zip
+      - unzip temp.zip -d {{.TOOLS_DIR}}
+
+  install:shfmt:
+    desc: Install shfmt
+    vars:
+      SHFMT_FILENAME: shfmt_{{.SHFMT_VERSION}}_{{OS}}_{{ARCH}}{{exeExt}}
+      SHFMT_DOWNLOAD_URL: https://github.com/mvdan/sh/releases/download/{{.SHFMT_VERSION}}/{{.SHFMT_FILENAME}}
+    status:
+      - test -x {{.TOOLS_DIR}}/shfmt{{exeExt}}
+    cmds:
+      - curl --fail --silent --show-error --location
+        --url {{.SHFMT_DOWNLOAD_URL}}
+        --output {{.TOOLS_DIR}}/shfmt{{exeExt}}
+      - '{{if ne OS "windows"}}chmod +x {{.TOOLS_DIR}}/shfmt{{end}}'
+
+  # ----------------------------------------------------------------------------
+  # Build tasks
+  # ----------------------------------------------------------------------------
+  clean: rm -rf dist
+
+  gobuild:
+    internal: true
+    generates:
+      - "{{.OUTPUT}}"
+    env:
+      CGO_ENABLED: 0
+      GOOS: "{{.GOOS}}"
+      GOARCH: "{{.GOARCH}}"
+    vars:
+      OUTPUT: '{{joinPath "dist" (list .GOOS .GOARCH | join "-") "bomctl"}}{{.EXT}}'
+    cmd: go build -trimpath -o {{.OUTPUT}} -ldflags="${LDFLAGS}"
+
+  build:
+    desc: Build binaries for all platforms and CPU architectures
+    cmds:
+      - task: build:linux:amd
+      - task: build:linux:arm
+      - task: build:macos:intel
+      - task: build:macos:apple
+      - task: build:windows:amd
+      - task: build:windows:arm
+
+  build:linux:amd:
+    desc: Build for Linux on AMD64
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: linux
+        GOARCH: amd64
+
+  build:linux:arm:
+    desc: Build for Linux on ARM
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: linux
+        GOARCH: arm64
+
+  build:macos:intel:
+    desc: Build for macOS on AMD64
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: darwin
+        GOARCH: amd64
+
+  build:macos:apple:
+    desc: Build for macOS on ARM
+    cmd:
+      task: gobuild
+      vars:
+        GOOS: darwin
+        GOARCH: arm64
+
+  build:windows:amd:
+    desc: Build for Windows on AMD64
+    cmd:
+      task: gobuild
+      vars:
+        EXT: .exe
+        GOOS: windows
+        GOARCH: amd64
+
+  build:windows:arm:
+    desc: Build for Windows on ARM
+    cmd:
+      task: gobuild
+      vars:
+        EXT: .exe
+        GOOS: windows
+        GOARCH: arm64
+
+  # ----------------------------------------------------------------------------
+  # Lint tasks
+  # ----------------------------------------------------------------------------
+  run-lint:
+    silent: true
+    vars:
+      CLI_ARGS: '{{.CLI_ARGS | join " "}}'
+    preconditions:
+      - sh: command -v {{.CLI_NAME}}
+        msg: "{{.CLI_NAME}} not found, please install and run the command again."
+    cmds:
+      - printf "\nRunning ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n"
+      - PATH={{.TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}${PATH} {{.CLI_NAME}} {{.CLI_ARGS}}
+
+  lint:
+    desc: Lint Golang code, markdown, shell scripts, and YAML files
+    cmds:
+      - task: lint:go
+      - task: lint:markdown
+      - task: lint:shell
+      - task: lint:yaml
+
+  lint:go:
+    desc: Lint Golang code files
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: golangci-lint
+        CLI_ARGS: [run, --verbose]
+
+  lint:go:fix:
+    desc: Fix golangci-lint findings
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: golangci-lint
+        CLI_ARGS: [run, --fix, --verbose]
+
+  lint:markdown:
+    desc: Lint markdown files
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: markdownlint-cli2
+        CLI_ARGS: "{{catLines .MARKDOWN_FILES}}"
+
+  lint:markdown:fix:
+    desc: Fix markdown lint findings
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: markdownlint-cli2
+        CLI_ARGS: [--fix, "{{catLines .MARKDOWN_FILES}}"]
+
+  lint:shell:
+    desc: Lint shell scripts
+    cmds:
+      - task: shellcheck
+      - task: shfmt
+
+  shellcheck:
+    internal: true
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: shellcheck
+        CLI_ARGS: ["{{catLines .SHELL_FILES}}"]
+
+  shfmt:
+    internal: true
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: shfmt
+        CLI_ARGS: [--diff, --simplify, "{{catLines .SHELL_FILES}}"]
+
+  lint:yaml:
+    desc: Lint YAML files
+    cmd:
+      task: run-lint
+      vars:
+        CLI_NAME: yamllint
+        CLI_ARGS: ["{{catLines .YAML_FILES}}"]
+
+  # ----------------------------------------------------------------------------
+  # Testing tasks
+  # ----------------------------------------------------------------------------
+  test:
+    desc: Run all tests
+    cmds:
+      - task: test:unit
+
+  test:unit:
+    desc: Run unit tests
+    cmd: go test -failfast -v -coverprofile=coverage.out -covermode=atomic ./...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,12 +38,12 @@ env:
   RESET: \033[0m
 
 vars:
-  BUILD_DATE:
-    sh: date -u +'%Y-%m-%dT%H:%M:%SZ'
+  BUILD_DATE: '{{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}'
   GIT_SHA:
     sh: git rev-parse HEAD
   GOLANGCI_LINT_INSTALL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
   GOLANGCI_LINT_VERSION: v1.60.3
+  GOLANGCI_LINT_RELEASE_URL: https://github.com/golangci/golangci-lint/releases/download/{{.GOLANGCI_LINT_VERSION}}
   MARKDOWN_FILES:
     sh: git ls-files '*.md'
   SHELL_FILES:
@@ -76,34 +76,40 @@ tasks:
 
   install:golangci-lint:
     desc: Install golangci-lint
-    status:
-      - test -x {{.TOOLS_DIR}}/golangci-lint
-    cmd: curl --fail --silent --show-error --location {{.GOLANGCI_LINT_INSTALL}} |
-      sh -s -- -b {{.TOOLS_DIR}} {{.GOLANGCI_LINT_VERSION}}
-
-  install:shellcheck:unix:
-    desc: Install shellcheck
-    platforms: [darwin, linux]
     vars:
-      SHELLCHECK_FILENAME: shellcheck-{{.SHELLCHECK_VERSION}}.{{OS}}.{{.SHELLCHECK_ARCH}}.tar.xz
-      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
+      GOLANGCI_LINT_PREFIX: golangci-lint-{{trimPrefix "v" .GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}
+      GOLANGCI_LINT_FILENAME: '{{.GOLANGCI_LINT_PREFIX}}{{if eq OS "windows"}}.zip{{else}}.tar.gz{{end}}'
+      GOLANGCI_LINT_DOWNLOAD_URL: "{{.GOLANGCI_LINT_RELEASE_URL}}/{{.GOLANGCI_LINT_FILENAME}}"
     status:
-      - test -x {{.TOOLS_DIR}}/shellcheck
-    cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} |
-      tar --extract --xz --directory {{.TOOLS_DIR}} --strip-components=1 shellcheck-{{.SHELLCHECK_VERSION}}/shellcheck
-
-  install:shellcheck:windows:
-    desc: Install shellcheck
-    platforms: [windows]
-    vars:
-      SHELLCHECK_FILENAME: shellcheck-{{.SHELLCHECK_VERSION}}.zip
-      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
-    status:
-      - test -x {{.TOOLS_DIR}}/shellcheck.exe
+      - test -x {{.TOOLS_DIR}}/golangci-lint{{exeExt}}
     cmds:
-      - curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --output temp.zip
-      - defer: rm -f temp.zip
-      - unzip temp.zip -d {{.TOOLS_DIR}}
+      - mkdir -p {{.TOOLS_DIR}}
+      - curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
+      - defer: rm -r {{.GOLANGCI_LINT_FILENAME}}
+      - cmd: tar --extract --gzip --file {{.GOLANGCI_LINT_FILENAME}} --directory {{.TOOLS_DIR}}
+          --strip-components=1 {{.GOLANGCI_LINT_PREFIX}}/golangci-lint
+        platforms: [darwin, linux]
+      - cmd: unzip {{.GOLANGCI_LINT_FILENAME}} {{.GOLANGCI_LINT_PREFIX}}/golangci-lint.exe -d {{.TOOLS_DIR}}
+        platforms: [windows]
+
+  install:shellcheck:
+    desc: Install shellcheck
+    vars:
+      SHELLCHECK_PREFIX: shellcheck-{{.SHELLCHECK_VERSION}}
+      SHELLCHECK_EXTENSION: '{{if eq OS "windows"}}.zip{{else}}.{{OS}}.{{.SHELLCHECK_ARCH}}.tar.xz{{end}}'
+      SHELLCHECK_FILENAME: "{{.SHELLCHECK_PREFIX}}{{.SHELLCHECK_EXTENSION}}"
+      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
+    status:
+      - test -x {{.TOOLS_DIR}}/shellcheck{{exeExt}}
+    cmds:
+      - mkdir -p {{.TOOLS_DIR}}
+      - curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
+      - defer: rm -r {{.SHELLCHECK_FILENAME}}
+      - cmd: tar --extract --xz --file {{.SHELLCHECK_FILENAME}} --directory {{.TOOLS_DIR}}
+          --strip-components=1 {{.SHELLCHECK_PREFIX}}/shellcheck
+        platforms: [darwin, linux]
+      - cmd: unzip {{.SHELLCHECK_FILENAME}} -d {{.TOOLS_DIR}}
+        platforms: [windows]
 
   install:shfmt:
     desc: Install shfmt
@@ -230,7 +236,7 @@ tasks:
     cmd:
       task: run-lint
       vars:
-        CLI_NAME: golangci-lint
+        CLI_NAME: golangci-lint{{exeExt}}
         CLI_ARGS: [run, --verbose]
 
   lint:go:fix:
@@ -238,7 +244,7 @@ tasks:
     cmd:
       task: run-lint
       vars:
-        CLI_NAME: golangci-lint
+        CLI_NAME: golangci-lint{{exeExt}}
         CLI_ARGS: [run, --fix, --verbose]
 
   lint:markdown:
@@ -262,12 +268,12 @@ tasks:
     cmds:
       - task: run-lint
         vars:
-          CLI_NAME: shellcheck
+          CLI_NAME: shellcheck{{exeExt}}
           CLI_ARGS: ["{{catLines .SHELL_FILES}}"]
 
       - task: run-lint
         vars:
-          CLI_NAME: shfmt
+          CLI_NAME: shfmt{{exeExt}}
           CLI_ARGS: [--diff, --simplify, "{{catLines .SHELL_FILES}}"]
 
   lint:shell:fix:
@@ -275,7 +281,7 @@ tasks:
     cmd:
       task: run-lint
       vars:
-        CLI_NAME: shfmt
+        CLI_NAME: shfmt{{exeExt}}
         CLI_ARGS: [--write, --simplify, "{{catLines .SHELL_FILES}}"]
 
   lint:yaml:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,8 +70,7 @@ tasks:
     desc: Install dev tools
     cmds:
       - task: install:golangci-lint
-      - task: install:shellcheck:unix
-      - task: install:shellcheck:windows
+      - task: install:shellcheck
       - task: install:shfmt
 
   install:golangci-lint:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,150 +21,50 @@
 
 version: "3"
 
+includes:
+  build:
+    taskfile: .taskfiles/build.yml
+
+  fix:
+    taskfile: .taskfiles/fix.yml
+    vars:
+      MARKDOWN_FILES: "{{.MARKDOWN_FILES}}"
+      SHELL_FILES: "{{.SHELL_FILES}}"
+
+  install:
+    taskfile: .taskfiles/install.yml
+    vars:
+      RM: "{{.RM}}"
+      TOOLS_DIR: "{{.TOOLS_DIR}}"
+
+  lint:
+    taskfile: .taskfiles/lint.yml
+    vars:
+      MARKDOWN_FILES: "{{.MARKDOWN_FILES}}"
+      SHELL_FILES: "{{.SHELL_FILES}}"
+      TOOLS_DIR: "{{.TOOLS_DIR}}"
+      YAML_FILES: "{{.YAML_FILES}}"
+
 env:
   GO111MODULE: "on"
   GOPATH:
     sh: go env GOPATH
   GOPROXY: https://proxy.golang.org,direct
-  LDFLAGS: -s -w
-    -X=github.com/bomctl/bomctl/cmd.VersionMajor={{.VERSION_MAJOR}}
-    -X=github.com/bomctl/bomctl/cmd.VersionMinor={{.VERSION_MINOR}}
-    -X=github.com/bomctl/bomctl/cmd.VersionPatch={{.VERSION_PATCH}}
-    -X=github.com/bomctl/bomctl/cmd.VersionPre={{.VERSION_PRE}}
-    -X=github.com/bomctl/bomctl/cmd.BuildDate={{.BUILD_DATE}}
-  BOLD: \033[1m
-  CYAN: \033[36m
-  YELLOW: \033[33m
-  RESET: \033[0m
 
 vars:
-  BUILD_DATE: '{{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}'
-  GIT_SHA:
-    sh: git rev-parse HEAD
-  GOLANGCI_LINT_INSTALL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-  GOLANGCI_LINT_VERSION: v1.60.3
-  GOLANGCI_LINT_RELEASE_URL: https://github.com/golangci/golangci-lint/releases/download/{{.GOLANGCI_LINT_VERSION}}
+  RM: '{{if eq OS "windows"}}powershell -Command "Remove-Item -Recurse -Force -Path"{{else}}rm -rf{{end}}'
   MARKDOWN_FILES:
     sh: git ls-files '*.md'
-  RM: '{{if eq OS "windows"}}powershell -Command "Remove-Item -Recurse -Force -Path"{{else}}rm -rf{{end}}'
   SHELL_FILES:
     sh: git ls-files '*.sh'
-  SHELLCHECK_ARCH: '{{eq ARCH "amd64" | ternary "x86_64" "aarch64"}}'
-  SHELLCHECK_VERSION: v0.10.0
-  SHELLCHECK_RELEASE_URL: https://github.com/koalaman/shellcheck/releases/download/{{.SHELLCHECK_VERSION}}
-  SHFMT_VERSION: v3.9.0
   TOOLS_DIR: '{{shellQuote (joinPath .ROOT_DIR ".bin")}}'
-  VERSION:
-    sh: '{{default "Undefined" "git describe --tags --abbrev=0"}}'
-  VERSION_REGEX: v(\d+)\.(\d+)\.(\d+)
-  VERSION_MAJOR: '{{regexReplaceAll .VERSION_REGEX .VERSION "${1}"}}'
-  VERSION_MINOR: '{{regexReplaceAll .VERSION_REGEX .VERSION "${2}"}}'
-  VERSION_PATCH: '{{regexReplaceAll .VERSION_REGEX .VERSION "${3}"}}'
   YAML_FILES:
     sh: git ls-files '*.yml' '*.yaml'
 
 tasks:
-  # ----------------------------------------------------------------------------
-  # Dev tools tasks
-  # ----------------------------------------------------------------------------
-  make-tools-dir:
+  default:
     silent: true
-    status:
-      - test -d {{.TOOLS_DIR}}
-    cmds:
-      - cmd: mkdir {{.TOOLS_DIR}}
-        platforms: [darwin, linux]
-
-      - cmd: powershell -Command '$null = New-Item -ItemType directory -Path {{shellQuote .TOOLS_DIR}}'
-        platforms: [windows]
-
-  unzip-windows:
-    internal: true
-    platforms: [windows]
-    cmd: powershell -Command 'Add-Type -Assembly System.IO.Compression.FileSystem;
-      $zip = [IO.Compression.ZipFile]::OpenRead("{{.ZIP_FILENAME}}");
-      $entry = $zip.Entries | Where-Object -Property Name -EQ "{{.EXE_FILENAME}}";
-      $target = {{shellQuote (joinPath .TOOLS_DIR .EXE_FILENAME)}};
-      [IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target)'
-
-  install:
-    desc: Install dev tools
-    cmds:
-      - task: install:golangci-lint
-      - task: install:shellcheck
-      - task: install:shfmt
-
-  install:golangci-lint:
-    desc: Install golangci-lint
-    vars:
-      GOLANGCI_LINT_PREFIX: golangci-lint-{{trimPrefix "v" .GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}
-      GOLANGCI_LINT_FILENAME: '{{.GOLANGCI_LINT_PREFIX}}{{if eq OS "windows"}}.zip{{else}}.tar.gz{{end}}'
-      GOLANGCI_LINT_DOWNLOAD_URL: "{{.GOLANGCI_LINT_RELEASE_URL}}/{{.GOLANGCI_LINT_FILENAME}}"
-    status:
-      - test -x "{{shellQuote .TOOLS_DIR}}/golangci-lint{{exeExt}}"
-    cmds:
-      - task: make-tools-dir
-      - cmd: curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
-      - defer: "{{.RM}} {{.GOLANGCI_LINT_FILENAME}}"
-      - cmd: tar --extract --gzip --file {{.GOLANGCI_LINT_FILENAME}} --directory {{.TOOLS_DIR}}
-          --strip-components=1 {{.GOLANGCI_LINT_PREFIX}}/golangci-lint
-        platforms: [darwin, linux]
-      - task: unzip-windows
-        vars:
-          ZIP_FILENAME: "{{.GOLANGCI_LINT_FILENAME}}"
-          EXE_FILENAME: golangci-lint.exe
-
-  install:shellcheck:
-    desc: Install shellcheck
-    vars:
-      SHELLCHECK_PREFIX: shellcheck-{{.SHELLCHECK_VERSION}}
-      SHELLCHECK_EXTENSION: '{{if eq OS "windows"}}.zip{{else}}.{{OS}}.{{.SHELLCHECK_ARCH}}.tar.xz{{end}}'
-      SHELLCHECK_FILENAME: "{{.SHELLCHECK_PREFIX}}{{.SHELLCHECK_EXTENSION}}"
-      SHELLCHECK_DOWNLOAD_URL: "{{.SHELLCHECK_RELEASE_URL}}/{{.SHELLCHECK_FILENAME}}"
-    status:
-      - test -x "{{shellQuote .TOOLS_DIR}}/shellcheck{{exeExt}}"
-    cmds:
-      - task: make-tools-dir
-      - cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
-      - defer: "{{.RM}} {{.SHELLCHECK_FILENAME}}"
-      - cmd: tar --extract --xz --file {{.SHELLCHECK_FILENAME}} --directory {{.TOOLS_DIR}}
-          --strip-components=1 {{.SHELLCHECK_PREFIX}}/shellcheck
-        platforms: [darwin, linux]
-      - task: unzip-windows
-        vars:
-          ZIP_FILENAME: "{{.SHELLCHECK_FILENAME}}"
-          EXE_FILENAME: shellcheck.exe
-
-  install:shfmt:
-    desc: Install shfmt
-    vars:
-      SHFMT_FILENAME: shfmt_{{.SHFMT_VERSION}}_{{OS}}_{{ARCH}}{{exeExt}}
-      SHFMT_DOWNLOAD_URL: https://github.com/mvdan/sh/releases/download/{{.SHFMT_VERSION}}/{{.SHFMT_FILENAME}}
-    status:
-      - test -x "{{shellQuote .TOOLS_DIR}}/shfmt{{exeExt}}"
-    cmds:
-      - task: make-tools-dir
-      - cmd: curl --fail --silent --show-error --location
-          --url {{.SHFMT_DOWNLOAD_URL}}
-          --output {{.TOOLS_DIR}}/shfmt{{exeExt}}
-      - cmd: '{{if ne OS "windows"}}chmod +x {{.TOOLS_DIR}}/shfmt{{end}}'
-
-  # ----------------------------------------------------------------------------
-  # Build tasks
-  # ----------------------------------------------------------------------------
-  clean: "{{.RM}} dist"
-
-  gobuild:
-    internal: true
-    generates:
-      - "{{.OUTPUT}}"
-    env:
-      CGO_ENABLED: 0
-      GOOS: "{{.GOOS}}"
-      GOARCH: "{{.GOARCH}}"
-    vars:
-      OUTPUT: '{{joinPath "dist" (list .GOOS .GOARCH | join "-") "bomctl"}}{{.EXT}}'
-    cmd: go build -trimpath -o {{.OUTPUT}} -ldflags="${LDFLAGS}"
+    cmd: task --list
 
   build:
     desc: Build binaries for all platforms and CPU architectures
@@ -176,71 +76,23 @@ tasks:
       - task: build:windows:amd
       - task: build:windows:arm
 
-  build:linux:amd:
-    desc: Build for Linux on AMD64
-    cmd:
-      task: gobuild
-      vars:
-        GOOS: linux
-        GOARCH: amd64
+  clean:
+    desc: Clean the working directory
+    cmd: "{{.RM}} dist"
 
-  build:linux:arm:
-    desc: Build for Linux on ARM
-    cmd:
-      task: gobuild
-      vars:
-        GOOS: linux
-        GOARCH: arm64
+  fix:
+    desc: Apply fixes to Golang code, markdown, and shell scripts where possible
+    cmds:
+      - task: fix:go
+      - task: fix:markdown
+      - task: fix:shell
 
-  build:macos:intel:
-    desc: Build for macOS on AMD64
-    cmd:
-      task: gobuild
-      vars:
-        GOOS: darwin
-        GOARCH: amd64
-
-  build:macos:apple:
-    desc: Build for macOS on ARM
-    cmd:
-      task: gobuild
-      vars:
-        GOOS: darwin
-        GOARCH: arm64
-
-  build:windows:amd:
-    desc: Build for Windows on AMD64
-    cmd:
-      task: gobuild
-      vars:
-        EXT: .exe
-        GOOS: windows
-        GOARCH: amd64
-
-  build:windows:arm:
-    desc: Build for Windows on ARM
-    cmd:
-      task: gobuild
-      vars:
-        EXT: .exe
-        GOOS: windows
-        GOARCH: arm64
-
-  # ----------------------------------------------------------------------------
-  # Lint tasks
-  # ----------------------------------------------------------------------------
-  run-lint:
-    silent: true
-    vars:
-      CLI_ARGS: '{{.CLI_ARGS | join " "}}'
-    cmd: >
-      export PATH="{{shellQuote .TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}{{env "PATH"}}";
-      if command -v {{.CLI_NAME}} > /dev/null; then
-        printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n";
-        {{.CLI_NAME}} {{.CLI_ARGS}};
-      else
-        printf "${YELLOW}{{.CLI_NAME}} not found, please install and run the command again.${RESET}\n";
-      fi
+  install:
+    desc: Install dev tools
+    cmds:
+      - task: install:golangci-lint
+      - task: install:shellcheck
+      - task: install:shfmt
 
   lint:
     desc: Lint Golang code, markdown, shell scripts, and YAML files
@@ -250,78 +102,6 @@ tasks:
       - task: lint:shell
       - task: lint:yaml
 
-  lint:fix:
-    desc: Lint Golang code, markdown, shell script, and YAML files, apply fixes where possible
-    cmds:
-      - task: lint:go:fix
-      - task: lint:markdown:fix
-      - task: lint:shell:fix
-      - task: lint:yaml
-
-  lint:go:
-    desc: Lint Golang code files
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: golangci-lint{{exeExt}}
-        CLI_ARGS: [run, --verbose]
-
-  lint:go:fix:
-    desc: Fix golangci-lint findings
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: golangci-lint{{exeExt}}
-        CLI_ARGS: [run, --fix, --verbose]
-
-  lint:markdown:
-    desc: Lint markdown files
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: markdownlint-cli2
-        CLI_ARGS: "{{catLines .MARKDOWN_FILES}}"
-
-  lint:markdown:fix:
-    desc: Fix markdown lint findings
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: markdownlint-cli2
-        CLI_ARGS: [--fix, "{{catLines .MARKDOWN_FILES}}"]
-
-  lint:shell:
-    desc: Lint shell scripts
-    cmds:
-      - task: run-lint
-        vars:
-          CLI_NAME: shellcheck{{exeExt}}
-          CLI_ARGS: ["{{catLines .SHELL_FILES}}"]
-
-      - task: run-lint
-        vars:
-          CLI_NAME: shfmt{{exeExt}}
-          CLI_ARGS: [--diff, --simplify, "{{catLines .SHELL_FILES}}"]
-
-  lint:shell:fix:
-    desc: Fix shell script lint findings
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: shfmt{{exeExt}}
-        CLI_ARGS: [--write, --simplify, "{{catLines .SHELL_FILES}}"]
-
-  lint:yaml:
-    desc: Lint YAML files
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: yamllint
-        CLI_ARGS: ["{{catLines .YAML_FILES}}"]
-
-  # ----------------------------------------------------------------------------
-  # Testing tasks
-  # ----------------------------------------------------------------------------
   test:
     desc: Run all tests
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,7 +52,7 @@ vars:
   SHELLCHECK_VERSION: v0.10.0
   SHELLCHECK_RELEASE_URL: https://github.com/koalaman/shellcheck/releases/download/{{.SHELLCHECK_VERSION}}
   SHFMT_VERSION: v3.9.0
-  TOOLS_DIR: '{{joinPath .ROOT_DIR ".bin"}}'
+  TOOLS_DIR: '{{shellQuote (joinPath .ROOT_DIR ".bin")}}'
   VERSION:
     sh: '{{default "Undefined" "git describe --tags --abbrev=0"}}'
   VERSION_REGEX: v(\d+)\.(\d+)\.(\d+)
@@ -66,6 +66,15 @@ tasks:
   # ----------------------------------------------------------------------------
   # Dev tools tasks
   # ----------------------------------------------------------------------------
+  make-tools-dir:
+    internal: true
+    cmds:
+      - cmd: mkdir -p {{.TOOLS_DIR}}
+        platforms: [darwin, linux]
+
+      - cmd: powershell -Command "New-Item -ItemType directory -Path {{.TOOLS_DIR}} -Force"
+        platforms: [windows]
+
   install:
     desc: Install dev tools
     cmds:
@@ -82,13 +91,13 @@ tasks:
     status:
       - test -x {{.TOOLS_DIR}}/golangci-lint{{exeExt}}
     cmds:
-      - mkdir -p {{.TOOLS_DIR}}
-      - curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
+      - task: make-tools-dir
+      - cmd: curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
       - defer: rm -r {{.GOLANGCI_LINT_FILENAME}}
       - cmd: tar --extract --gzip --file {{.GOLANGCI_LINT_FILENAME}} --directory {{.TOOLS_DIR}}
           --strip-components=1 {{.GOLANGCI_LINT_PREFIX}}/golangci-lint
         platforms: [darwin, linux]
-      - cmd: unzip {{.GOLANGCI_LINT_FILENAME}} {{.GOLANGCI_LINT_PREFIX}}/golangci-lint.exe -d {{.TOOLS_DIR}}
+      - cmd: unzip -j {{.GOLANGCI_LINT_FILENAME}} {{.GOLANGCI_LINT_PREFIX}}/golangci-lint.exe -d {{.TOOLS_DIR}}
         platforms: [windows]
 
   install:shellcheck:
@@ -101,13 +110,13 @@ tasks:
     status:
       - test -x {{.TOOLS_DIR}}/shellcheck{{exeExt}}
     cmds:
-      - mkdir -p {{.TOOLS_DIR}}
-      - curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
+      - task: make-tools-dir
+      - cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
       - defer: rm -r {{.SHELLCHECK_FILENAME}}
       - cmd: tar --extract --xz --file {{.SHELLCHECK_FILENAME}} --directory {{.TOOLS_DIR}}
           --strip-components=1 {{.SHELLCHECK_PREFIX}}/shellcheck
         platforms: [darwin, linux]
-      - cmd: unzip {{.SHELLCHECK_FILENAME}} -d {{.TOOLS_DIR}}
+      - cmd: unzip -j {{.SHELLCHECK_FILENAME}} -d {{.TOOLS_DIR}}
         platforms: [windows]
 
   install:shfmt:
@@ -118,10 +127,11 @@ tasks:
     status:
       - test -x {{.TOOLS_DIR}}/shfmt{{exeExt}}
     cmds:
-      - curl --fail --silent --show-error --location
-        --url {{.SHFMT_DOWNLOAD_URL}}
-        --output {{.TOOLS_DIR}}/shfmt{{exeExt}}
-      - '{{if ne OS "windows"}}chmod +x {{.TOOLS_DIR}}/shfmt{{end}}'
+      - task: make-tools-dir
+      - cmd: curl --fail --silent --show-error --location
+          --url {{.SHFMT_DOWNLOAD_URL}}
+          --output {{.TOOLS_DIR}}/shfmt{{exeExt}}
+      - cmd: '{{if ne OS "windows"}}chmod +x {{.TOOLS_DIR}}/shfmt{{end}}'
 
   # ----------------------------------------------------------------------------
   # Build tasks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,7 +84,7 @@ tasks:
     cmd: powershell -Command 'Add-Type -Assembly System.IO.Compression.FileSystem;
       $zip = [IO.Compression.ZipFile]::OpenRead("{{.ZIP_FILENAME}}");
       $entry = $zip.Entries | Where-Object -Property Name -EQ "{{.EXE_FILENAME}}";
-      $target = "{{shellQuote (joinPath .TOOLS_DIR "{{.EXE_FILENAME}}")}}";
+      $target = {{shellQuote (joinPath .TOOLS_DIR .EXE_FILENAME)}};
       [IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target)'
 
   install:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -206,7 +206,7 @@ tasks:
       - sh: command -v {{.CLI_NAME}}
         msg: "{{.CLI_NAME}} not found, please install and run the command again."
     cmds:
-      - printf "\nRunning ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n"
+      - printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n"
       - PATH={{.TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}${PATH} {{.CLI_NAME}} {{.CLI_ARGS}}
 
   lint:
@@ -215,6 +215,14 @@ tasks:
       - task: lint:go
       - task: lint:markdown
       - task: lint:shell
+      - task: lint:yaml
+
+  lint:fix:
+    desc: Lint Golang code, markdown, shell script, and YAML files, apply fixes where possible
+    cmds:
+      - task: lint:go:fix
+      - task: lint:markdown:fix
+      - task: lint:shell:fix
       - task: lint:yaml
 
   lint:go:
@@ -252,24 +260,23 @@ tasks:
   lint:shell:
     desc: Lint shell scripts
     cmds:
-      - task: shellcheck
-      - task: shfmt
+      - task: run-lint
+        vars:
+          CLI_NAME: shellcheck
+          CLI_ARGS: ["{{catLines .SHELL_FILES}}"]
 
-  shellcheck:
-    internal: true
-    cmd:
-      task: run-lint
-      vars:
-        CLI_NAME: shellcheck
-        CLI_ARGS: ["{{catLines .SHELL_FILES}}"]
+      - task: run-lint
+        vars:
+          CLI_NAME: shfmt
+          CLI_ARGS: [--diff, --simplify, "{{catLines .SHELL_FILES}}"]
 
-  shfmt:
-    internal: true
+  lint:shell:fix:
+    desc: Fix shell script lint findings
     cmd:
       task: run-lint
       vars:
         CLI_NAME: shfmt
-        CLI_ARGS: [--diff, --simplify, "{{catLines .SHELL_FILES}}"]
+        CLI_ARGS: [--write, --simplify, "{{catLines .SHELL_FILES}}"]
 
   lint:yaml:
     desc: Lint YAML files

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,6 +46,7 @@ vars:
   GOLANGCI_LINT_RELEASE_URL: https://github.com/golangci/golangci-lint/releases/download/{{.GOLANGCI_LINT_VERSION}}
   MARKDOWN_FILES:
     sh: git ls-files '*.md'
+  RM: '{{if eq OS "windows"}}powershell -Command "Remove-Item -Recurse -Force -Path"{{else}}rm -rf{{end}}'
   SHELL_FILES:
     sh: git ls-files '*.sh'
   SHELLCHECK_ARCH: '{{eq ARCH "amd64" | ternary "x86_64" "aarch64"}}'
@@ -67,12 +68,14 @@ tasks:
   # Dev tools tasks
   # ----------------------------------------------------------------------------
   make-tools-dir:
-    internal: true
+    silent: true
+    status:
+      - test -d {{.TOOLS_DIR}}
     cmds:
-      - cmd: mkdir -p {{.TOOLS_DIR}}
+      - cmd: mkdir {{.TOOLS_DIR}}
         platforms: [darwin, linux]
 
-      - cmd: powershell -Command "New-Item -ItemType directory -Path {{.TOOLS_DIR}} -Force"
+      - cmd: powershell -Command "New-Item -ItemType directory -Path {{.TOOLS_DIR}}"
         platforms: [windows]
 
   install:
@@ -93,7 +96,7 @@ tasks:
     cmds:
       - task: make-tools-dir
       - cmd: curl --fail --silent --show-error --location --url {{.GOLANGCI_LINT_DOWNLOAD_URL}} --remote-name
-      - defer: rm -r {{.GOLANGCI_LINT_FILENAME}}
+      - defer: "{{.RM}} {{.GOLANGCI_LINT_FILENAME}}"
       - cmd: tar --extract --gzip --file {{.GOLANGCI_LINT_FILENAME}} --directory {{.TOOLS_DIR}}
           --strip-components=1 {{.GOLANGCI_LINT_PREFIX}}/golangci-lint
         platforms: [darwin, linux]
@@ -112,7 +115,7 @@ tasks:
     cmds:
       - task: make-tools-dir
       - cmd: curl --fail --silent --show-error --location --url {{.SHELLCHECK_DOWNLOAD_URL}} --remote-name
-      - defer: rm -r {{.SHELLCHECK_FILENAME}}
+      - defer: "{{.RM}} {{.SHELLCHECK_FILENAME}}"
       - cmd: tar --extract --xz --file {{.SHELLCHECK_FILENAME}} --directory {{.TOOLS_DIR}}
           --strip-components=1 {{.SHELLCHECK_PREFIX}}/shellcheck
         platforms: [darwin, linux]
@@ -136,7 +139,7 @@ tasks:
   # ----------------------------------------------------------------------------
   # Build tasks
   # ----------------------------------------------------------------------------
-  clean: rm -rf dist
+  clean: "{{.RM}} dist"
 
   gobuild:
     internal: true
@@ -217,12 +220,14 @@ tasks:
     silent: true
     vars:
       CLI_ARGS: '{{.CLI_ARGS | join " "}}'
-    preconditions:
-      - sh: command -v {{.CLI_NAME}}
-        msg: "{{.CLI_NAME}} not found, please install and run the command again."
-    cmds:
-      - printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n"
-      - PATH={{.TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}${PATH} {{.CLI_NAME}} {{.CLI_ARGS}}
+    cmd: >
+      export PATH="{{.TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}{{env "PATH"}}";
+      if command -v {{.CLI_NAME}} > /dev/null; then
+        printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n";
+        {{.CLI_NAME}} {{.CLI_ARGS}};
+      else
+        printf "${YELLOW}{{.CLI_NAME}} not found, please install and run the command again.${RESET}\n";
+      fi
 
   lint:
     desc: Lint Golang code, markdown, shell scripts, and YAML files


### PR DESCRIPTION
## Description

This PR adds developer support for `task`, a tool similar to `make` written in Go. It provides a better development experience from platform to platform, whereas `make` isn't easily installable for Windows users.

See all available tasks by running `task --list` from within the project directory.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings