### PR TITLE
fix: export command info log moved to only log when outputting a file

### DIFF
--- a/internal/pkg/export/export.go
+++ b/internal/pkg/export/export.go
@@ -34,8 +34,6 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 		return fmt.Errorf("%w", err)
 	}
 
-	opts.Logger.Info("Exporting document", "sbomID", sbomID)
-
 	wr := writer.New(writer.WithFormat(opts.Format))
 
 	document, err := backend.GetDocumentByID(sbomID)
@@ -45,6 +43,8 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 
 	if opts.OutputFile != nil {
 		// Write the SBOM document bytes to file.
+		opts.Logger.Info("Exporting document", "sbomID", sbomID)
+
 		if err := wr.WriteFile(document, opts.OutputFile.Name()); err != nil {
 			return fmt.Errorf("%w", err)
 		}

--- a/internal/pkg/export/export.go
+++ b/internal/pkg/export/export.go
@@ -34,6 +34,8 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 		return fmt.Errorf("%w", err)
 	}
 
+	opts.Logger.Info("Exporting document", "sbomID", sbomID)
+
 	wr := writer.New(writer.WithFormat(opts.Format))
 
 	document, err := backend.GetDocumentByID(sbomID)
@@ -43,8 +45,6 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 
 	if opts.OutputFile != nil {
 		// Write the SBOM document bytes to file.
-		opts.Logger.Info("Exporting document", "sbomID", sbomID)
-
 		if err := wr.WriteFile(document, opts.OutputFile.Name()); err != nil {
 			return fmt.Errorf("%w", err)
 		}

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -33,7 +33,7 @@ func New(prefix string) *log.Logger {
 		styles.Levels[level] = styles.Levels[level].MaxWidth(levelWidth).Width(levelWidth)
 	}
 
-	logger := log.NewWithOptions(os.Stdout, log.Options{Prefix: prefix, Level: log.GetLevel()})
+	logger := log.NewWithOptions(os.Stderr, log.Options{Prefix: prefix, Level: log.GetLevel()})
 	logger.SetStyles(styles)
 
 	return logger


### PR DESCRIPTION
## Description

This PR fixes #149.

When piping `bomctl export ...` to another command, we should not be printing logging info to stdout. This is cause SBOM schema failures on the tools receiving the sbom content.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

```
./bomctl fetch https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/bomctl_bomctl_v0.3.0.cdx.json
./bomctl ls
./bomctl export urn:uuid:f360ad8b-dc41-4256-afed-337a04dff5db
./bomctl export urn:uuid:f360ad8b-dc41-4256-afed-337a04dff5db | grype
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
