### PR TITLE
chore: enable protogetter and varnamelen linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters:
     - prealloc
     - predeclared
     - promlinter
+    - protogetter
     - revive
     - staticcheck
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - varnamelen
     - wastedassign
     - whitespace
     - wrapcheck

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -136,10 +136,10 @@ func formatOptions() []string {
 	return append(spdxFormats, cdxFormats...)
 }
 
-func parseFormat(fs, encoding string) (formats.Format, error) {
+func parseFormat(formatStr, encoding string) (formats.Format, error) {
 	results := map[string]string{}
 	pattern := regexp.MustCompile("^(?P<name>[^-]+)(?:-(?P<version>.*))?")
-	match := pattern.FindStringSubmatch(fs)
+	match := pattern.FindStringSubmatch(formatStr)
 
 	for idx, name := range match {
 		results[pattern.SubexpNames()[idx]] = name
@@ -152,7 +152,7 @@ func parseFormat(fs, encoding string) (formats.Format, error) {
 		return formats.EmptyFormat, err
 	}
 
-	if err := validateEncoding(fs, encoding); err != nil {
+	if err := validateEncoding(formatStr, encoding); err != nil {
 		return formats.EmptyFormat, err
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -108,10 +108,10 @@ func styleFunc(row, col int) lipgloss.Style {
 }
 
 func getRow(doc *sbom.Document) []string {
-	id := doc.Metadata.Name
+	id := doc.GetMetadata().GetName()
 	if id == "" {
-		id = doc.Metadata.Id
+		id = doc.GetMetadata().GetId()
 	}
 
-	return []string{id, doc.Metadata.Version, fmt.Sprint(len(doc.NodeList.Nodes))}
+	return []string{id, doc.GetMetadata().GetVersion(), fmt.Sprint(len(doc.GetNodeList().GetNodes()))}
 }

--- a/internal/pkg/client/git/client_test.go
+++ b/internal/pkg/client/git/client_test.go
@@ -92,7 +92,7 @@ func (gs *gitSuite) SetupSuite() {
 	for _, document := range gs.docs {
 		err := gs.backend.AddDocument(document)
 		if err != nil {
-			gs.Fail("failed retrieving document", "id", document.Metadata.Id)
+			gs.Fail("failed retrieving document", "id", document.GetMetadata().GetId())
 		}
 	}
 

--- a/internal/pkg/client/git/push_test.go
+++ b/internal/pkg/client/git/push_test.go
@@ -38,7 +38,7 @@ func (gs *gitSuite) TestPush() {
 			UseTree: false,
 		}
 
-		err := gs.gc.Push(document.Metadata.Id, rawURL, opts)
+		err := gs.gc.Push(document.GetMetadata().GetId(), rawURL, opts)
 		if err != nil {
 			gs.T().Logf("Error testing Push: %s", err.Error())
 		}
@@ -70,13 +70,13 @@ func (gs *gitSuite) TestAddFile() {
 
 func (gs *gitSuite) TestGetDocument() {
 	for _, document := range gs.docs {
-		retrieved, err := git.GetDocument(document.Metadata.Id, gs.opts)
+		retrieved, err := git.GetDocument(document.GetMetadata().GetId(), gs.opts)
 		if err != nil {
-			gs.FailNow("failed retrieving document", "id", document.Metadata.Id)
+			gs.FailNow("failed retrieving document", "id", document.GetMetadata().GetId())
 		}
 
-		gs.Require().Equal(document.Metadata.Id, retrieved.Metadata.Id)
-		gs.Require().Len(retrieved.NodeList.Nodes, len(document.NodeList.Nodes))
-		gs.Require().Equal(document.NodeList.RootElements, retrieved.NodeList.RootElements)
+		gs.Require().Equal(document.GetMetadata().GetId(), retrieved.GetMetadata().GetId())
+		gs.Require().Len(retrieved.GetNodeList().GetNodes(), len(document.GetNodeList().GetNodes()))
+		gs.Require().Equal(document.GetNodeList().GetRootElements(), retrieved.GetNodeList().GetRootElements())
 	}
 }

--- a/internal/pkg/client/oci/fetch.go
+++ b/internal/pkg/client/oci/fetch.go
@@ -138,16 +138,16 @@ func getSBOMDescriptor(successors []ocispec.Descriptor) (*ocispec.Descriptor, er
 		sbomDigests    []string
 	)
 
-	for _, s := range successors {
+	for _, successor := range successors {
 		if slices.Contains([]string{
 			"application/vnd.cyclonedx",
 			"application/vnd.cyclonedx+json",
 			"application/spdx",
 			"application/spdx+json",
 			"text/spdx",
-		}, s.MediaType) {
-			sbomDescriptor = s
-			sbomDigests = append(sbomDigests, s.Digest.String())
+		}, successor.MediaType) {
+			sbomDescriptor = successor
+			sbomDigests = append(sbomDigests, successor.Digest.String())
 		}
 	}
 

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -110,13 +110,13 @@ func consolidateEdges(edges []*sbom.Edge) []*sbom.Edge {
 		edgeType string
 	}][]string)
 
-	for _, e := range edges {
+	for _, edge := range edges {
 		key := struct {
 			fromID   string
 			edgeType string
-		}{e.GetFrom(), e.GetType().String()}
+		}{edge.GetFrom(), edge.GetType().String()}
 
-		edgeMap[key] = append(edgeMap[key], e.GetTo()...)
+		edgeMap[key] = append(edgeMap[key], edge.GetTo()...)
 	}
 
 	for typedEdge, toIDs := range edgeMap {

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -74,25 +74,25 @@ func (dbs *dbSuite) TearDownSuite() {
 func (dbs *dbSuite) TestAddDocument() {
 	for _, document := range dbs.documents {
 		if err := dbs.backend.AddDocument(document); err != nil {
-			dbs.Fail("failed storing document", "id", document.Metadata.Id)
+			dbs.Fail("failed storing document", "id", document.GetMetadata().GetId())
 		}
 	}
 }
 
 func (dbs *dbSuite) TestGetDocumentByID() {
 	for _, document := range dbs.documents {
-		retrieved, err := dbs.backend.GetDocumentByID(document.Metadata.Id)
+		retrieved, err := dbs.backend.GetDocumentByID(document.GetMetadata().GetId())
 		if err != nil {
-			dbs.Fail("failed retrieving document", "id", document.Metadata.Id)
+			dbs.Fail("failed retrieving document", "id", document.GetMetadata().GetId())
 		}
 
-		expectedEdges := consolidateEdges(document.NodeList.Edges)
-		actualEdges := consolidateEdges(retrieved.NodeList.Edges)
+		expectedEdges := consolidateEdges(document.GetNodeList().GetEdges())
+		actualEdges := consolidateEdges(retrieved.GetNodeList().GetEdges())
 
-		dbs.Require().Equal(document.Metadata.Id, retrieved.Metadata.Id)
-		dbs.Require().Len(retrieved.NodeList.Nodes, len(document.NodeList.Nodes))
+		dbs.Require().Equal(document.GetMetadata().GetId(), retrieved.GetMetadata().GetId())
+		dbs.Require().Len(retrieved.GetNodeList().GetNodes(), len(document.GetNodeList().GetNodes()))
 		dbs.Require().Equal(expectedEdges, actualEdges)
-		dbs.Require().Equal(document.NodeList.RootElements, retrieved.NodeList.RootElements)
+		dbs.Require().Equal(document.GetNodeList().GetRootElements(), retrieved.GetNodeList().GetRootElements())
 	}
 }
 
@@ -114,9 +114,9 @@ func consolidateEdges(edges []*sbom.Edge) []*sbom.Edge {
 		key := struct {
 			fromID   string
 			edgeType string
-		}{e.From, e.Type.String()}
+		}{e.GetFrom(), e.GetType().String()}
 
-		edgeMap[key] = append(edgeMap[key], e.To...)
+		edgeMap[key] = append(edgeMap[key], e.GetTo()...)
 	}
 
 	for typedEdge, toIDs := range edgeMap {
@@ -133,7 +133,7 @@ func consolidateEdges(edges []*sbom.Edge) []*sbom.Edge {
 		}
 	}
 
-	slices.SortStableFunc(consolidated, func(a, b *sbom.Edge) int { return cmp.Compare(a.From, b.From) })
+	slices.SortStableFunc(consolidated, func(a, b *sbom.Edge) int { return cmp.Compare(a.GetFrom(), b.GetFrom()) })
 
 	return consolidated
 }

--- a/internal/pkg/export/export.go
+++ b/internal/pkg/export/export.go
@@ -66,14 +66,14 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 // docuements so that the current document can serialize correctly.
 func cleanupEdges(document *sbom.Document) {
 	nodeIDs := []string{}
-	for _, node := range document.NodeList.Nodes {
-		nodeIDs = append(nodeIDs, node.Id)
+	for _, node := range document.GetNodeList().GetNodes() {
+		nodeIDs = append(nodeIDs, node.GetId())
 	}
 
 	edges := []*sbom.Edge{}
 
-	for _, edge := range document.NodeList.Edges {
-		if slices.Contains(nodeIDs, edge.From) {
+	for _, edge := range document.GetNodeList().GetEdges() {
+		if slices.Contains(nodeIDs, edge.GetFrom()) {
 			edges = append(edges, edge)
 		}
 	}

--- a/internal/pkg/export/export.go
+++ b/internal/pkg/export/export.go
@@ -24,7 +24,7 @@ import (
 	"slices"
 
 	"github.com/protobom/protobom/pkg/sbom"
-	"github.com/protobom/protobom/pkg/writer"
+	protowriter "github.com/protobom/protobom/pkg/writer"
 
 	"github.com/bomctl/bomctl/internal/pkg/db"
 	"github.com/bomctl/bomctl/internal/pkg/options"
@@ -38,7 +38,7 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 
 	opts.Logger.Info("Exporting document", "sbomID", sbomID)
 
-	wr := writer.New(writer.WithFormat(opts.Format))
+	writer := protowriter.New(protowriter.WithFormat(opts.Format))
 
 	document, err := backend.GetDocumentByID(sbomID)
 	if err != nil {
@@ -49,12 +49,12 @@ func Export(sbomID string, opts *options.ExportOptions) error {
 
 	if opts.OutputFile != nil {
 		// Write the SBOM document bytes to file.
-		if err := wr.WriteFile(document, opts.OutputFile.Name()); err != nil {
+		if err := writer.WriteFile(document, opts.OutputFile.Name()); err != nil {
 			return fmt.Errorf("%w", err)
 		}
 	} else {
 		// Write the SBOM document bytes to stdout.
-		if err := wr.WriteStream(document, os.Stdout); err != nil {
+		if err := writer.WriteStream(document, os.Stdout); err != nil {
 			return fmt.Errorf("%w", err)
 		}
 	}

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -86,7 +86,7 @@ func GetRemoteDocument(sbomURL string, opts *options.FetchOptions) (*sbom.Docume
 }
 
 func fetchExternalReferences(document *sbom.Document, backend *db.Backend, opts *options.FetchOptions) error {
-	extRefs, err := backend.GetExternalReferencesByDocumentID(document.Metadata.Id, "BOM")
+	extRefs, err := backend.GetExternalReferencesByDocumentID(document.GetMetadata().GetId(), "BOM")
 	if err != nil {
 		return fmt.Errorf("error getting external references: %w", err)
 	}
@@ -103,7 +103,7 @@ func fetchExternalReferences(document *sbom.Document, backend *db.Backend, opts 
 			defer extRefsOpt.OutputFile.Close() //nolint:revive
 		}
 
-		if err := Fetch(ref.Url, &extRefsOpt); err != nil {
+		if err := Fetch(ref.GetUrl(), &extRefsOpt); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/merge/merge_test.go
+++ b/internal/pkg/merge/merge_test.go
@@ -72,7 +72,7 @@ func (ms *mergeSuite) SetupSuite() {
 	for _, document := range ms.docs {
 		err := ms.backend.AddDocument(document)
 		if err != nil {
-			ms.Fail("failed retrieving document", "id", document.Metadata.Id)
+			ms.Fail("failed retrieving document", "id", document.GetMetadata().GetId())
 		}
 	}
 
@@ -94,7 +94,7 @@ func (ms *mergeSuite) TestMerge() {
 		Options: ms.opts,
 	}
 
-	docID, err := merge.Merge([]string{ms.docs[0].Metadata.Id, ms.docs[1].Metadata.Id}, opts)
+	docID, err := merge.Merge([]string{ms.docs[0].GetMetadata().GetId(), ms.docs[1].GetMetadata().GetId()}, opts)
 
 	ms.Require().NoError(err)
 
@@ -103,15 +103,15 @@ func (ms *mergeSuite) TestMerge() {
 		ms.Fail("Failed to get merged document from DB")
 	}
 
-	if ms.docs[0].Metadata.Name != "" {
-		ms.Equal(ms.docs[0].Metadata.Name, mergedDoc.Metadata.Name)
-	} else if ms.docs[0].Metadata.Name == "" && ms.docs[1].Metadata.Name != "" {
-		ms.Equal(ms.docs[1].Metadata.Name, mergedDoc.Metadata.Name)
+	if ms.docs[0].GetMetadata().GetName() != "" {
+		ms.Equal(ms.docs[0].GetMetadata().GetName(), mergedDoc.GetMetadata().GetName())
+	} else if ms.docs[0].GetMetadata().GetName() == "" && ms.docs[1].GetMetadata().GetName() != "" {
+		ms.Equal(ms.docs[1].GetMetadata().GetName(), mergedDoc.GetMetadata().GetName())
 	}
 
-	expectedToolLength := len(ms.docs[0].Metadata.Tools) + len(ms.docs[1].Metadata.Tools)
+	expectedToolLength := len(ms.docs[0].GetMetadata().GetTools()) + len(ms.docs[1].GetMetadata().GetTools())
 
-	ms.Len(mergedDoc.Metadata.Tools, expectedToolLength)
+	ms.Len(mergedDoc.GetMetadata().GetTools(), expectedToolLength)
 }
 
 func TestMergeSuite(t *testing.T) {

--- a/internal/pkg/merge/merger.go
+++ b/internal/pkg/merge/merger.go
@@ -43,22 +43,22 @@ var (
 	errCastFailure  = errors.New("failed to cast object")
 )
 
-func (m *MergerBase[T]) MergeProtoMessage(t T) (err error) {
+func (m *MergerBase[T]) MergeProtoMessage(msg T) (err error) {
 	switch base := any(m.Base).(type) {
 	case *sbom.Metadata:
-		return mergeMetadata(base, t)
+		return mergeMetadata(base, msg)
 	case *sbom.Node:
-		return mergeNode(base, t)
+		return mergeNode(base, msg)
 	case *sbom.NodeList:
-		return mergeNodeList(base, t)
+		return mergeNodeList(base, msg)
 	case *sbom.Person:
-		return mergePerson(base, t)
+		return mergePerson(base, msg)
 	case *sbom.Tool:
-		return mergeTool(base, t)
+		return mergeTool(base, msg)
 	case *sbom.DocumentType:
-		return mergeDocumentType(base, t)
+		return mergeDocumentType(base, msg)
 	default:
-		return fmt.Errorf("%w: %T", errMergeFailure, t)
+		return fmt.Errorf("%w: %T", errMergeFailure, msg)
 	}
 }
 

--- a/internal/pkg/merge/merger.go
+++ b/internal/pkg/merge/merger.go
@@ -68,13 +68,13 @@ func mergeMetadata(base *sbom.Metadata, t proto.Message) error {
 		return fmt.Errorf("%w: %T", errCastFailure, other)
 	}
 
-	base.Comment = mergeStrings(base.Comment, other.Comment)
-	base.Id = mergeStrings(base.Id, other.Id)
-	base.Name = mergeStrings(base.Name, other.Name)
-	base.Version = mergeStrings(base.Version, other.Version)
+	base.Comment = mergeStrings(base.GetComment(), other.GetComment())
+	base.Id = mergeStrings(base.GetId(), other.GetId())
+	base.Name = mergeStrings(base.GetName(), other.GetName())
+	base.Version = mergeStrings(base.GetVersion(), other.GetVersion())
 
-	if base.Date == nil && other.Date != nil {
-		base.Date = other.Date
+	if base.GetDate() == nil && other.GetDate() != nil {
+		base.Date = other.GetDate()
 	}
 
 	err := mergeMetadataSlices(base, other)
@@ -88,17 +88,17 @@ func mergeMetadata(base *sbom.Metadata, t proto.Message) error {
 func mergeMetadataSlices(base, other *sbom.Metadata) error {
 	var err error
 
-	base.Tools, err = mergeTools(base.Tools, other.Tools)
+	base.Tools, err = mergeTools(base.GetTools(), other.GetTools())
 	if err != nil {
 		return err
 	}
 
-	base.Authors, err = mergePersons(base.Authors, other.Authors)
+	base.Authors, err = mergePersons(base.GetAuthors(), other.GetAuthors())
 	if err != nil {
 		return err
 	}
 
-	base.DocumentTypes, err = mergeDocumentTypes(base.DocumentTypes, other.DocumentTypes)
+	base.DocumentTypes, err = mergeDocumentTypes(base.GetDocumentTypes(), other.GetDocumentTypes())
 
 	return err
 }
@@ -117,7 +117,7 @@ func dedupeTools(tools []*sbom.Tool) ([]*sbom.Tool, error) {
 	toolMap := make(map[string]*sbom.Tool)
 
 	for _, tool := range tools {
-		key := fmt.Sprintf("%s-%s", tool.Name, tool.Version)
+		key := fmt.Sprintf("%s-%s", tool.GetName(), tool.GetVersion())
 		if _, exists := toolMap[key]; !exists {
 			toolMap[key] = tool
 			dedupedList = append(dedupedList, tool)
@@ -153,9 +153,9 @@ func mergeNodeList(base *sbom.NodeList, t proto.Message) error {
 
 	mergedNodeList := base.Union(other)
 
-	base.Nodes = mergedNodeList.Nodes
-	base.Edges = mergedNodeList.Edges
-	base.RootElements = mergedNodeList.RootElements
+	base.Nodes = mergedNodeList.GetNodes()
+	base.Edges = mergedNodeList.GetEdges()
+	base.RootElements = mergedNodeList.GetRootElements()
 
 	return nil
 }
@@ -166,13 +166,13 @@ func mergePerson(base *sbom.Person, t proto.Message) error {
 		return fmt.Errorf("%w: %T", errCastFailure, t)
 	}
 
-	base.Email = mergeStrings(base.Email, other.Email)
-	base.Name = mergeStrings(base.Name, other.Name)
-	base.Phone = mergeStrings(base.Phone, other.Phone)
-	base.Url = mergeStrings(base.Url, other.Url)
+	base.Email = mergeStrings(base.GetEmail(), other.GetEmail())
+	base.Name = mergeStrings(base.GetName(), other.GetName())
+	base.Phone = mergeStrings(base.GetPhone(), other.GetPhone())
+	base.Url = mergeStrings(base.GetUrl(), other.GetUrl())
 
 	var err error
-	base.Contacts, err = mergePersons(base.Contacts, other.Contacts)
+	base.Contacts, err = mergePersons(base.GetContacts(), other.GetContacts())
 
 	return err
 }
@@ -191,7 +191,7 @@ func dedupePersons(persons []*sbom.Person) ([]*sbom.Person, error) {
 	personMap := make(map[string]*sbom.Person)
 
 	for _, person := range persons {
-		email := person.Email
+		email := person.GetEmail()
 		if _, exists := personMap[email]; !exists {
 			personMap[email] = person
 			dedupedList = append(dedupedList, person)
@@ -214,9 +214,9 @@ func mergeTool(base *sbom.Tool, t proto.Message) error {
 		return fmt.Errorf("%w: %T", errCastFailure, t)
 	}
 
-	base.Name = mergeStrings(base.Name, other.Name)
-	base.Vendor = mergeStrings(base.Vendor, other.Vendor)
-	base.Version = mergeStrings(base.Version, other.Version)
+	base.Name = mergeStrings(base.GetName(), other.GetName())
+	base.Vendor = mergeStrings(base.GetVendor(), other.GetVendor())
+	base.Version = mergeStrings(base.GetVersion(), other.GetVersion())
 
 	return nil
 }
@@ -227,16 +227,19 @@ func mergeDocumentType(base *sbom.DocumentType, t proto.Message) error {
 		return fmt.Errorf("%w: %T", errCastFailure, t)
 	}
 
-	if (base.Name == nil || *base.Name == "") && other.Name != nil {
-		base.Name = other.Name
+	if base.GetName() == "" && other.GetName() != "" {
+		name := other.GetName()
+		base.Name = &name
 	}
 
 	if base.Type == nil && other.Type != nil {
-		base.Type = other.Type
+		typ := other.GetType()
+		base.Type = &typ
 	}
 
-	if (base.Description == nil || *base.Description == "") && other.Description != nil {
-		base.Description = other.Description
+	if base.GetDescription() == "" && other.GetDescription() != "" {
+		desc := other.GetDescription()
+		base.Description = &desc
 	}
 
 	return nil
@@ -256,7 +259,7 @@ func dedupeDocumentTypes(documentTypes []*sbom.DocumentType) ([]*sbom.DocumentTy
 	documentTypeMap := make(map[string]*sbom.DocumentType)
 
 	for _, documentType := range documentTypes {
-		key := *documentType.Name
+		key := documentType.GetName()
 		if _, exists := documentTypeMap[key]; !exists {
 			documentTypeMap[key] = documentType
 			dedupedList = append(dedupedList, documentType)

--- a/internal/pkg/push/push.go
+++ b/internal/pkg/push/push.go
@@ -86,16 +86,16 @@ func processExtRefDocs(sbomID, destPath string, opts *options.PushOptions) error
 // checks local db for fetched document identifiers,
 // returns local data if found, otherwise uses fetched data.
 func getDocumentInfo(be *db.Backend, doc *sbom.Document) (id, name string, err error) {
-	existingDoc, err := be.GetDocumentByID(doc.Metadata.Id)
+	existingDoc, err := be.GetDocumentByID(doc.GetMetadata().GetId())
 	if err != nil {
 		if err = be.AddDocument(doc); err != nil {
 			return "", "", fmt.Errorf("failed to store document: %w", err)
 		}
 
-		return doc.Metadata.Id, doc.Metadata.Name, nil
+		return doc.GetMetadata().GetId(), doc.GetMetadata().GetName(), nil
 	}
 
-	return existingDoc.Metadata.Id, existingDoc.Metadata.Name, nil
+	return existingDoc.GetMetadata().GetId(), existingDoc.GetMetadata().GetName(), nil
 }
 
 // generate destination path to push to based on what
@@ -119,7 +119,7 @@ func getExtRefPath(destPath, docID, docName string, opts *options.PushOptions) s
 }
 
 func pushExtRefDoc(ref *sbom.ExternalReference, be *db.Backend, destPath string, opts *options.PushOptions) error {
-	opts.Logger.Info("Fetching External Ref Bom from URL", "refUrl", ref.Url)
+	opts.Logger.Info("Fetching External Ref Bom from URL", "refUrl", ref.GetUrl())
 
 	// Parse push options into fetch
 	fetchOpts := &options.FetchOptions{
@@ -128,7 +128,7 @@ func pushExtRefDoc(ref *sbom.ExternalReference, be *db.Backend, destPath string,
 	}
 
 	// call fetch wrapper function to fetch extref doc object
-	doc, err := fetch.GetRemoteDocument(ref.Url, fetchOpts)
+	doc, err := fetch.GetRemoteDocument(ref.GetUrl(), fetchOpts)
 	if err != nil {
 		return fmt.Errorf("error fetching external reference docs: %w", err)
 	}

--- a/internal/pkg/push/push.go
+++ b/internal/pkg/push/push.go
@@ -118,7 +118,7 @@ func getExtRefPath(destPath, docID, docName string, opts *options.PushOptions) s
 	return (destDir + fileName + ext)
 }
 
-func pushExtRefDoc(ref *sbom.ExternalReference, be *db.Backend, destPath string, opts *options.PushOptions) error {
+func pushExtRefDoc(ref *sbom.ExternalReference, backend *db.Backend, destPath string, opts *options.PushOptions) error {
 	opts.Logger.Info("Fetching External Ref Bom from URL", "refUrl", ref.GetUrl())
 
 	// Parse push options into fetch
@@ -134,7 +134,7 @@ func pushExtRefDoc(ref *sbom.ExternalReference, be *db.Backend, destPath string,
 	}
 
 	// check local db to see if this file already exists
-	docID, docName, err := getDocumentInfo(be, doc)
+	docID, docName, err := getDocumentInfo(backend, doc)
 	if err != nil {
 		return fmt.Errorf("failed to import external ref bom: %w", err)
 	}


### PR DESCRIPTION
## Description

This PR enables the `protogetter` and `varnamelen` linters for `golanci-lint`.

### protogetter

Reports direct reads from proto message fields when getters should be used.

This should significantly reduce instances of panic due to `invalid memory address or nil pointer dereference`. Fixes were automatically applied with `golangci-lint run --fix`, except lines 230-243 in merger.go which generated incorrect code and needed manual edits.

### varnamelen

Checks that the length of a variable's name matches its scope.

Fixes were manually applied, but no logic was modified.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified `task lint` and `task test` locally.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings