### PR TITLE
feat: document annotations for source data, hash, format, and URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,7 +84,7 @@
   "go.coverMode": "atomic",
   "go.coverOnSave": true,
   "go.coverOnSingleTest": true,
-  "go.lintFlags": ["--fast", "--allow-parallel-runners", "--config=.golangci.yml"],
+  "go.lintFlags": ["--fast"],
   "go.lintOnSave": "file",
   "go.lintTool": "golangci-lint",
   "go.testFlags": ["-race", "-covermode=atomic"],

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -58,7 +58,7 @@ func fetchCmd() *cobra.Command {
 			}
 
 			for _, url := range args {
-				if err := fetch.Fetch(url, opts); err != nil {
+				if _, err := fetch.Fetch(url, opts); err != nil {
 					opts.Logger.Fatal(err)
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,8 +120,7 @@ func rootCmd() *cobra.Command {
 				log.SetLevel(log.DebugLevel)
 			}
 
-			cacheDir, err := cmd.Flags().GetString("cache-dir")
-			cobra.CheckErr(err)
+			cacheDir := viper.GetString("cache_dir")
 
 			// Get first top-level subcommand.
 			subcmd := cmd

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jdx/go-netrc v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/protobom/protobom v0.4.3
-	github.com/protobom/storage v0.1.4
+	github.com/protobom/storage v0.1.5
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/protobom/protobom v0.4.3 h1:Z1oig/zVUNg1FK/cDqW9MFGdT0thd12FvcX6t8jUUH8=
 github.com/protobom/protobom v0.4.3/go.mod h1:Ky6/lq6BIcVGYCzLHZQTOunX1OiF5W9fPjgrok095VQ=
-github.com/protobom/storage v0.1.4 h1:/U3bmi9J9CpjQO5Xd+nrNmitapcz/WNpmiYhZp7/Kjs=
-github.com/protobom/storage v0.1.4/go.mod h1:NKQ+KbXRtALFJReZmJu/r+5TVPP0qGdt3ZLb63q+zcY=
+github.com/protobom/storage v0.1.5 h1:AfxR+IOPdR+4pLCH9DfX3F3B4KFWMOVIS31HBWnEZ0o=
+github.com/protobom/storage v0.1.5/go.mod h1:NKQ+KbXRtALFJReZmJu/r+5TVPP0qGdt3ZLb63q+zcY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/pkg/client/git/client_test.go
+++ b/internal/pkg/client/git/client_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
@@ -49,11 +50,19 @@ func (gs *gitSuite) SetupSuite() {
 	var err error
 
 	if gs.tmpDir, err = os.MkdirTemp("", "testrepo"); err != nil {
-		gs.T().Fatalf("failed to create temporary directory: %v", err)
+		gs.T().Fatalf("Failed to create temporary directory: %v", err)
 	}
 
 	if gs.repo, err = gogit.PlainInit(gs.tmpDir, false); err != nil {
-		gs.T().Fatalf("failed to initialize git repo: %v", err)
+		gs.T().Fatalf("Failed to initialize Git repo: %v", err)
+	}
+
+	repoConfig := config.NewConfig()
+	repoConfig.Author.Name = "bomctl-unit-test"
+	repoConfig.Author.Email = "bomctl-unit-test@users.noreply.github.com"
+
+	if err := gs.repo.SetConfig(repoConfig); err != nil {
+		gs.T().Fatalf("Failed to set Git repo config: %v", err)
 	}
 
 	if gs.backend, err = db.NewBackend(db.WithDatabaseFile(db.DatabaseFile)); err != nil {

--- a/internal/pkg/client/git/client_test.go
+++ b/internal/pkg/client/git/client_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	gogit "github.com/go-git/go-git/v5"
-	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
@@ -36,82 +35,68 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
-var TestDataDir = filepath.Join("..", "..", "db", "testdata")
-
 type gitSuite struct {
 	suite.Suite
-	tempDir string
+	tmpDir  string
 	repo    *gogit.Repository
 	opts    *options.Options
 	backend *db.Backend
 	gc      *git.Client
-	doc     *sbom.Document
 	docs    []*sbom.Document
 }
 
 func (gs *gitSuite) SetupSuite() {
-	dir, err := os.MkdirTemp("", "testrepo")
-	if err != nil {
+	var err error
+
+	if gs.tmpDir, err = os.MkdirTemp("", "testrepo"); err != nil {
 		gs.T().Fatalf("failed to create temporary directory: %v", err)
 	}
 
-	gs.tempDir = dir
-
-	r, err := gogit.PlainInit(dir, false)
-	if err != nil {
+	if gs.repo, err = gogit.PlainInit(gs.tmpDir, false); err != nil {
 		gs.T().Fatalf("failed to initialize git repo: %v", err)
 	}
 
-	gs.repo = r
+	if gs.backend, err = db.NewBackend(db.WithDatabaseFile(db.DatabaseFile)); err != nil {
+		gs.T().Fatalf("%v", err)
+	}
 
-	sboms, err := os.ReadDir(TestDataDir)
+	testdataDir := filepath.Join("..", "..", "db", "testdata")
+
+	sboms, err := os.ReadDir(testdataDir)
 	if err != nil {
 		gs.T().Fatalf("%v", err)
 	}
 
-	rdr := reader.New()
 	for sbomIdx := range sboms {
-		doc, err := rdr.ParseFile(filepath.Join(TestDataDir, sboms[sbomIdx].Name()))
+		sbomData, err := os.ReadFile(filepath.Join(testdataDir, sboms[sbomIdx].Name()))
 		if err != nil {
 			gs.T().Fatalf("%v", err)
+		}
+
+		doc, err := gs.backend.AddDocument(sbomData)
+		if err != nil {
+			gs.FailNow("failed storing document", "err", err)
 		}
 
 		gs.docs = append(gs.docs, doc)
 	}
 
-	gs.opts = options.New().
-		WithCacheDir(viper.GetString("cache_dir"))
-
-	gs.backend, err = db.NewBackend(
-		db.WithDatabaseFile(filepath.Join(viper.GetString("cache_dir"), db.DatabaseFile)),
-	)
-	if err != nil {
-		gs.T().Fatalf("%v", err)
-	}
-
-	for _, document := range gs.docs {
-		err := gs.backend.AddDocument(document)
-		if err != nil {
-			gs.Fail("failed retrieving document", "id", document.GetMetadata().GetId())
-		}
-	}
-
+	gs.opts = options.New().WithCacheDir(viper.GetString("cache_dir"))
 	gs.opts = gs.opts.WithContext(context.WithValue(context.Background(), db.BackendKey{}, gs.backend))
-
 	gs.gc = &git.Client{}
 }
 
 func (gs *gitSuite) TearDownSuite() {
-	err := os.RemoveAll(gs.tempDir)
+	err := os.RemoveAll(gs.tmpDir)
 	if err != nil {
-		gs.T().Logf("Error removing repo file %s", db.DatabaseFile)
+		gs.T().Fatalf("Error removing repo file %s", db.DatabaseFile)
 	}
 
 	gs.backend.CloseClient()
 
 	if _, err := os.Stat(db.DatabaseFile); err == nil {
 		if err := os.Remove(db.DatabaseFile); err != nil {
-			gs.T().Logf("Error removing database file %s", db.DatabaseFile)
+			gs.T().Fatalf("Error removing database file %s", db.DatabaseFile)
 		}
 	}
 }

--- a/internal/pkg/client/git/push_test.go
+++ b/internal/pkg/client/git/push_test.go
@@ -60,12 +60,12 @@ func (gs *gitSuite) TestAddFile() {
 		Fragment: "test/file.sbom",
 	}
 
-	err := git.AddFile(gs.repo, path.Join(gs.tempDir, "test", "file.sbom"), &pOptions, gs.doc, parsedURL)
-	if err != nil {
-		gs.T().Logf("Error testing addFile: %s", err.Error())
-	}
+	gs.Require().NoError(
+		git.AddFile(gs.repo, path.Join(gs.tmpDir, "test", "file.sbom"), &pOptions, gs.docs[0], parsedURL),
+		"Error testing addFile",
+	)
 
-	gs.Assert().FileExists(path.Join(gs.tempDir, "test", "file.sbom"))
+	gs.Require().FileExists(path.Join(gs.tmpDir, "test", "file.sbom"))
 }
 
 func (gs *gitSuite) TestGetDocument() {

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -19,20 +19,30 @@
 package db
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 
 	"github.com/charmbracelet/log"
+	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/protobom/protobom/pkg/storage"
 	"github.com/protobom/storage/backends/ent"
 
 	"github.com/bomctl/bomctl/internal/pkg/logger"
 )
 
 const (
-	DatabaseFile  string = "bomctl.db"
-	EntDebugLevel int    = 2
+	SourceDataAnnotation   string = "bomctl_annotation_source_data"
+	SourceHashAnnotation   string = "bomctl_annotation_source_hash"
+	SourceFormatAnnotation string = "bomctl_annotation_source_format"
+	SourceURLAnnotation    string = "bomctl_annotation_source_url"
+
+	DatabaseFile string = "bomctl.db"
+
+	EntDebugLevel int = 2
 )
 
 type (
@@ -80,13 +90,43 @@ func NewBackend(opts ...Option) (*Backend, error) {
 	return backend, nil
 }
 
-// AddDocument adds the protobom Document to the database.
-func (backend *Backend) AddDocument(document *sbom.Document) error {
-	if err := backend.Store(document, nil); err != nil {
-		return fmt.Errorf("failed to store document: %w", err)
+// AddDocument adds the protobom Document to the database and annotates with its source data, hash, and format.
+func (backend *Backend) AddDocument(sbomData []byte) (*sbom.Document, error) {
+	sbomReader := reader.New()
+
+	document, err := sbomReader.ParseStream(bytes.NewReader(sbomData))
+	if err != nil {
+		return nil, fmt.Errorf("parsing SBOM data: %w", err)
 	}
 
-	return nil
+	hash := sha256.Sum256(sbomData)
+	opts := &storage.StoreOptions{
+		BackendOptions: &ent.BackendOptions{
+			Annotations: ent.Annotations{
+				{
+					Name:     SourceDataAnnotation,
+					Value:    string(sbomData),
+					IsUnique: true,
+				},
+				{
+					Name:     SourceHashAnnotation,
+					Value:    string(hash[:]),
+					IsUnique: true,
+				},
+				{
+					Name:     SourceFormatAnnotation,
+					Value:    sbomReader.Options.Format.Type(),
+					IsUnique: true,
+				},
+			},
+		},
+	}
+
+	if err := backend.Store(document, opts); err != nil {
+		return nil, fmt.Errorf("storing document %s: %w", document.GetMetadata().GetId(), err)
+	}
+
+	return document, nil
 }
 
 // GetDocumentByID retrieves a protobom Document with the specified ID from the database.

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -25,7 +25,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/stretchr/testify/suite"
 
@@ -39,7 +38,12 @@ type dbSuite struct {
 }
 
 func (dbs *dbSuite) SetupSuite() {
-	rdr := reader.New()
+	backend, err := db.NewBackend(db.WithDatabaseFile(db.DatabaseFile))
+	if err != nil {
+		dbs.T().Fatalf("%v", err)
+	}
+
+	dbs.backend = backend
 
 	sboms, err := os.ReadDir("testdata")
 	if err != nil {
@@ -47,17 +51,17 @@ func (dbs *dbSuite) SetupSuite() {
 	}
 
 	for sbomIdx := range sboms {
-		doc, err := rdr.ParseFile(filepath.Join("testdata", sboms[sbomIdx].Name()))
+		sbomData, err := os.ReadFile(filepath.Join("testdata", sboms[sbomIdx].Name()))
 		if err != nil {
 			dbs.T().Fatalf("%v", err)
 		}
 
-		dbs.documents = append(dbs.documents, doc)
-	}
+		doc, err := dbs.backend.AddDocument(sbomData)
+		if err != nil {
+			dbs.FailNow("failed storing document", "err", err)
+		}
 
-	dbs.backend, err = db.NewBackend(db.WithDatabaseFile(db.DatabaseFile))
-	if err != nil {
-		dbs.T().Fatalf("%v", err)
+		dbs.documents = append(dbs.documents, doc)
 	}
 }
 
@@ -67,14 +71,6 @@ func (dbs *dbSuite) TearDownSuite() {
 	if _, err := os.Stat(db.DatabaseFile); err == nil {
 		if err := os.Remove(db.DatabaseFile); err != nil {
 			dbs.T().Logf("Error removing database file %s", db.DatabaseFile)
-		}
-	}
-}
-
-func (dbs *dbSuite) TestAddDocument() {
-	for _, document := range dbs.documents {
-		if err := dbs.backend.AddDocument(document); err != nil {
-			dbs.Fail("failed storing document", "id", document.GetMetadata().GetId())
 		}
 	}
 }
@@ -124,7 +120,6 @@ func consolidateEdges(edges []*sbom.Edge) []*sbom.Edge {
 			slices.Sort(toIDs)
 
 			edgeType := sbom.Edge_Type_value[typedEdge.edgeType]
-
 			consolidated = append(consolidated, &sbom.Edge{
 				Type: sbom.Edge_Type(edgeType),
 				From: typedEdge.fromID,

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -27,7 +27,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
 
 	"github.com/bomctl/bomctl/internal/pkg/client"
@@ -35,27 +34,12 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-func Fetch(sbomURL string, opts *options.FetchOptions) error {
+func Fetch(sbomURL string, opts *options.FetchOptions) (*sbom.Document, error) {
 	backend, err := db.BackendFromContext(opts.Context())
 	if err != nil {
-		return fmt.Errorf("%w", err)
+		return nil, fmt.Errorf("%w", err)
 	}
 
-	doc, err := GetRemoteDocument(sbomURL, opts)
-	if err != nil {
-		return err
-	}
-
-	// Insert fetched document data into database.
-	if err := backend.AddDocument(doc); err != nil {
-		return fmt.Errorf("error adding document: %w", err)
-	}
-
-	// Fetch externally referenced BOMs
-	return fetchExternalReferences(doc, backend, opts)
-}
-
-func GetRemoteDocument(sbomURL string, opts *options.FetchOptions) (*sbom.Document, error) {
 	fetcher, err := client.New(sbomURL)
 	if err != nil {
 		return nil, fmt.Errorf("creating fetch client: %w", err)
@@ -75,14 +59,22 @@ func GetRemoteDocument(sbomURL string, opts *options.FetchOptions) (*sbom.Docume
 		}
 	}
 
-	sbomReader := reader.New()
-
-	document, err := sbomReader.ParseStream(bytes.NewReader(sbomData))
+	// Insert fetched document data into database.
+	doc, err := backend.AddDocument(sbomData)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing SBOM file content: %w", err)
+		return nil, fmt.Errorf("adding document: %w", err)
 	}
 
-	return document, nil
+	if err := backend.SetUniqueAnnotation(
+		doc.GetMetadata().GetId(), db.SourceURLAnnotation, sbomURL,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"applying unique annotation %s to %s: %w", db.SourceURLAnnotation, doc.GetMetadata().GetId(), err,
+		)
+	}
+
+	// Fetch externally referenced BOMs
+	return doc, fetchExternalReferences(doc, backend, opts)
 }
 
 func fetchExternalReferences(document *sbom.Document, backend *db.Backend, opts *options.FetchOptions) error {
@@ -92,18 +84,18 @@ func fetchExternalReferences(document *sbom.Document, backend *db.Backend, opts 
 	}
 
 	for _, ref := range extRefs {
-		extRefsOpt := *opts
-		if extRefsOpt.OutputFile != nil {
+		extRefOpts := *opts
+		if extRefOpts.OutputFile != nil {
 			out, err := getRefFile(opts.OutputFile)
 			if err != nil {
 				return err
 			}
 
-			extRefsOpt.OutputFile = out
-			defer extRefsOpt.OutputFile.Close() //nolint:revive
+			extRefOpts.OutputFile = out
+			defer extRefOpts.OutputFile.Close() //nolint:revive
 		}
 
-		if err := Fetch(ref.GetUrl(), &extRefsOpt); err != nil {
+		if _, err := Fetch(ref.GetUrl(), &extRefOpts); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/import/import.go
+++ b/internal/pkg/import/import.go
@@ -19,11 +19,8 @@
 package imprt
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-
-	"github.com/protobom/protobom/pkg/reader"
 
 	"github.com/bomctl/bomctl/internal/pkg/db"
 	"github.com/bomctl/bomctl/internal/pkg/options"
@@ -35,21 +32,14 @@ func Import(opts *options.ImportOptions) error {
 		return fmt.Errorf("%w", err)
 	}
 
-	sbomReader := reader.New()
-
 	for idx := range opts.InputFiles {
 		data, err := io.ReadAll(opts.InputFiles[idx])
 		if err != nil {
 			return fmt.Errorf("failed to read from %s: %w", opts.InputFiles[idx].Name(), err)
 		}
 
-		document, err := sbomReader.ParseStream(bytes.NewReader(data))
-		if err != nil {
-			return fmt.Errorf("failed to parse %s: %w", opts.InputFiles[idx].Name(), err)
-		}
-
-		if err := backend.AddDocument(document); err != nil {
-			return fmt.Errorf("failed to store document: %w", err)
+		if _, err := backend.AddDocument(data); err != nil {
+			return fmt.Errorf("%w", err)
 		}
 	}
 

--- a/internal/pkg/merge/merge.go
+++ b/internal/pkg/merge/merge.go
@@ -60,8 +60,8 @@ func Merge(documentIDs []string, opts *options.MergeOptions) (string, error) {
 
 	backend.Logger.Info("Adding merged document", "sbomID", merged.GetMetadata().GetId())
 
-	if err := backend.AddDocument(merged); err != nil {
-		merged.Metadata.Id = ""
+	if err := backend.Store(merged, nil); err != nil {
+		return "", fmt.Errorf("%w", err)
 	}
 
 	return merged.GetMetadata().GetId(), err

--- a/internal/pkg/merge/merge_test.go
+++ b/internal/pkg/merge/merge_test.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
@@ -44,16 +43,27 @@ type mergeSuite struct {
 }
 
 func (ms *mergeSuite) SetupSuite() {
+	backend, err := db.NewBackend(db.WithDatabaseFile(db.DatabaseFile))
+	if err != nil {
+		ms.T().Fatalf("%v", err)
+	}
+
+	ms.backend = backend
+
 	sboms, err := os.ReadDir(TestDataDir)
 	if err != nil {
 		ms.T().Fatalf("%v", err)
 	}
 
-	rdr := reader.New()
 	for sbomIdx := range sboms {
-		doc, err := rdr.ParseFile(filepath.Join(TestDataDir, sboms[sbomIdx].Name()))
+		sbomData, err := os.ReadFile(filepath.Join(TestDataDir, sboms[sbomIdx].Name()))
 		if err != nil {
 			ms.T().Fatalf("%v", err)
+		}
+
+		doc, err := ms.backend.AddDocument(sbomData)
+		if err != nil {
+			ms.FailNow("failed storing document", "err", err)
 		}
 
 		ms.docs = append(ms.docs, doc)
@@ -67,13 +77,6 @@ func (ms *mergeSuite) SetupSuite() {
 	)
 	if err != nil {
 		ms.T().Fatalf("%v", err)
-	}
-
-	for _, document := range ms.docs {
-		err := ms.backend.AddDocument(document)
-		if err != nil {
-			ms.Fail("failed retrieving document", "id", document.GetMetadata().GetId())
-		}
 	}
 
 	ms.opts = ms.opts.WithContext(context.WithValue(context.Background(), db.BackendKey{}, ms.backend))

--- a/internal/pkg/push/push.go
+++ b/internal/pkg/push/push.go
@@ -85,10 +85,10 @@ func processExtRefDocs(sbomID, destPath string, opts *options.PushOptions) error
 
 // checks local db for fetched document identifiers,
 // returns local data if found, otherwise uses fetched data.
-func getDocumentInfo(be *db.Backend, doc *sbom.Document) (id, name string, err error) {
-	existingDoc, err := be.GetDocumentByID(doc.GetMetadata().GetId())
+func getDocumentInfo(backend *db.Backend, doc *sbom.Document) (id, name string, err error) {
+	existingDoc, err := backend.GetDocumentByID(doc.GetMetadata().GetId())
 	if err != nil {
-		if err = be.AddDocument(doc); err != nil {
+		if err = backend.Store(doc, nil); err != nil {
 			return "", "", fmt.Errorf("failed to store document: %w", err)
 		}
 
@@ -128,7 +128,7 @@ func pushExtRefDoc(ref *sbom.ExternalReference, backend *db.Backend, destPath st
 	}
 
 	// call fetch wrapper function to fetch extref doc object
-	doc, err := fetch.GetRemoteDocument(ref.GetUrl(), fetchOpts)
+	doc, err := fetch.Fetch(ref.GetUrl(), fetchOpts)
 	if err != nil {
 		return fmt.Errorf("error fetching external reference docs: %w", err)
 	}

--- a/internal/pkg/url/url.go
+++ b/internal/pkg/url/url.go
@@ -70,6 +70,7 @@ func (url *ParsedURL) String() string {
 		)
 	}
 
+	urlString = strings.Join(removeEmpty(url.Port), ":")
 	urlString = strings.Join(removeEmpty(url.Path), pathSep)
 	urlString = strings.Join(removeEmpty(url.GitRef), "@")
 	urlString = strings.Join(removeEmpty(url.Query), "?")


### PR DESCRIPTION
## Description

This PR adds annotations in the database for each document fetched. The new annotation names are:

- `bomctl_annotation_source_data` - bytes content of fetched document
- `bomctl_annotation_source_hash` - hash of fetched document
- `bomctl_annotation_source_format` - original format of fetched document
- `bomctl_annotation_source_url` - URL of fetched document 

Fixes #68 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] updated Go tests
- [X] run locally and verify database contents

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings