### PR TITLE
style: util package naming

### DIFF
--- a/.taskfiles/install.yml
+++ b/.taskfiles/install.yml
@@ -22,7 +22,7 @@
 version: "3"
 
 vars:
-  GOLANGCI_LINT_VERSION: v1.60.3
+  GOLANGCI_LINT_VERSION: v1.61.0
   GOLANGCI_LINT_RELEASE_URL: https://github.com/golangci/golangci-lint/releases/download/{{.GOLANGCI_LINT_VERSION}}
   SHELLCHECK_ARCH: '{{eq ARCH "amd64" | ternary "x86_64" "aarch64"}}'
   SHELLCHECK_VERSION: v0.10.0

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bomctl/bomctl/internal/pkg/outpututils"
+	"github.com/bomctl/bomctl/internal/pkg/outpututil"
 )
 
 func listCmd() *cobra.Command {
@@ -54,7 +54,7 @@ func listCmd() *cobra.Command {
 				}
 			}
 
-			listOutput := outpututils.NewTable()
+			listOutput := outpututil.NewTable()
 			for _, document := range documents {
 				listOutput.AddRow(document, backend)
 			}

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -26,14 +26,14 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/client/git"
 	"github.com/bomctl/bomctl/internal/pkg/client/http"
 	"github.com/bomctl/bomctl/internal/pkg/client/oci"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
 var errUnsupportedURL = errors.New("failed to parse URL; see `--help` for valid URL patterns")
 
 type Client interface {
-	url.Parser
+	netutil.Parser
 	AddFile(pushURL, id string, opts *options.PushOptions) error
 	Name() string
 	Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error)
@@ -43,7 +43,7 @@ type Client interface {
 
 func New(sbomURL string) (Client, error) {
 	for _, client := range []Client{&git.Client{}, &http.Client{}, &oci.Client{}} {
-		if parsedURL := client.Parse(sbomURL); parsedURL != nil {
+		if url := client.Parse(sbomURL); url != nil {
 			return client, nil
 		}
 	}

--- a/internal/pkg/client/git/client.go
+++ b/internal/pkg/client/git/client.go
@@ -28,8 +28,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/storage/memory"
 
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
 type Client struct {
@@ -54,7 +54,7 @@ func (*Client) RegExp() *regexp.Regexp {
 	)
 }
 
-func (client *Client) Parse(rawURL string) *url.ParsedURL {
+func (client *Client) Parse(rawURL string) *netutil.URL {
 	results := map[string]string{}
 	pattern := client.RegExp()
 	match := pattern.FindStringSubmatch(rawURL)
@@ -74,7 +74,7 @@ func (client *Client) Parse(rawURL string) *url.ParsedURL {
 		}
 	}
 
-	return &url.ParsedURL{
+	return &netutil.URL{
 		Scheme:   results["scheme"],
 		Username: results["username"],
 		Password: results["password"],
@@ -87,22 +87,22 @@ func (client *Client) Parse(rawURL string) *url.ParsedURL {
 	}
 }
 
-func (client *Client) cloneRepo(parsedURL *url.ParsedURL, auth *url.BasicAuth, opts *options.Options) (err error) {
-	client.basePath = parsedURL.Fragment
+func (client *Client) cloneRepo(url *netutil.URL, auth *netutil.BasicAuth, opts *options.Options) (err error) {
+	client.basePath = url.Fragment
 
 	// Copy parsedRepoURL, excluding auth, git ref, and fragment.
-	baseURL := &url.ParsedURL{
-		Scheme:   parsedURL.Scheme,
-		Hostname: parsedURL.Hostname,
-		Path:     parsedURL.Path,
-		Port:     parsedURL.Port,
+	baseURL := &netutil.URL{
+		Scheme:   url.Scheme,
+		Hostname: url.Hostname,
+		Path:     url.Path,
+		Port:     url.Port,
 	}
 
 	cloneOpts := &git.CloneOptions{
 		URL:           baseURL.String(),
 		Auth:          auth,
 		RemoteName:    git.DefaultRemoteName,
-		ReferenceName: plumbing.NewBranchReferenceName(parsedURL.GitRef),
+		ReferenceName: plumbing.NewBranchReferenceName(url.GitRef),
 		SingleBranch:  true,
 		Depth:         1,
 	}

--- a/internal/pkg/client/git/client_test.go
+++ b/internal/pkg/client/git/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/bomctl/bomctl/internal/pkg/client/git"
-	"github.com/bomctl/bomctl/internal/pkg/url"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 )
 
 type gitClientSuite struct {
@@ -36,14 +36,14 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 	client := &git.Client{}
 
 	for _, data := range []struct {
-		expected *url.ParsedURL
+		expected *netutil.URL
 		name     string
 		url      string
 	}{
 		{
 			name: "git+http scheme",
 			url:  "git+http://github.com/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "http",
 				Hostname: "github.com",
 				Path:     "bomctl/bomctl.git",
@@ -54,7 +54,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git+https scheme with username, port",
 			url:  "git+https://git@github.com:12345/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "https",
 				Username: "git",
 				Hostname: "github.com",
@@ -67,7 +67,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git+https scheme with username, password, port",
 			url:  "git+https://username:password@github.com:12345/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "https",
 				Username: "username",
 				Password: "password",
@@ -81,7 +81,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git+https scheme with username",
 			url:  "git+https://git@github.com/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "https",
 				Username: "git",
 				Hostname: "github.com",
@@ -93,7 +93,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "ssh scheme",
 			url:  "ssh://github.com/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Hostname: "github.com",
 				Path:     "bomctl/bomctl.git",
@@ -104,7 +104,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "ssh scheme with username, port",
 			url:  "ssh://git@github.com:12345/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Username: "git",
 				Hostname: "github.com",
@@ -117,7 +117,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "ssh scheme with username, password, port",
 			url:  "ssh://username:password@github.com:12345/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Username: "username",
 				Password: "password",
@@ -131,7 +131,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "ssh scheme with username",
 			url:  "ssh://git@github.com/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Username: "git",
 				Hostname: "github.com",
@@ -143,7 +143,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git scheme",
 			url:  "git://github.com/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "git",
 				Hostname: "github.com",
 				Path:     "bomctl/bomctl.git",
@@ -154,7 +154,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git scheme with username, port",
 			url:  "git://git@github.com:12345/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "git",
 				Username: "git",
 				Hostname: "github.com",
@@ -167,7 +167,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git scheme with username, password, port",
 			url:  "git://username:password@github.com:12345/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "git",
 				Username: "username",
 				Password: "password",
@@ -181,7 +181,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git scheme with username",
 			url:  "git://git@github.com/bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "git",
 				Username: "git",
 				Hostname: "github.com",
@@ -193,7 +193,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git SCP-like syntax",
 			url:  "github.com:bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Hostname: "github.com",
 				Path:     "bomctl/bomctl.git",
@@ -204,7 +204,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git SCP-like syntax with username",
 			url:  "git@github.com:bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Username: "git",
 				Hostname: "github.com",
@@ -216,7 +216,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git SCP-like syntax with username, password",
 			url:  "username:password@github.com:bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Username: "username",
 				Password: "password",
@@ -229,7 +229,7 @@ func (gcs *gitClientSuite) TestClient_Parse() {
 		{
 			name: "git SCP-like syntax with username",
 			url:  "git@github.com:bomctl/bomctl.git@main#sbom.cdx.json",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "ssh",
 				Username: "git",
 				Hostname: "github.com",

--- a/internal/pkg/client/git/push.go
+++ b/internal/pkg/client/git/push.go
@@ -30,8 +30,8 @@ import (
 	"github.com/protobom/protobom/pkg/writer"
 
 	"github.com/bomctl/bomctl/internal/pkg/db"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
 func (client *Client) AddFile(pushURL, id string, opts *options.PushOptions) error {
@@ -40,8 +40,8 @@ func (client *Client) AddFile(pushURL, id string, opts *options.PushOptions) err
 		return err
 	}
 
-	parsedURL := client.Parse(pushURL)
-	name := parsedURL.Fragment
+	url := client.Parse(pushURL)
+	name := url.Fragment
 
 	// Create any parent directories specified in fragment.
 	if dir := filepath.Dir(name); dir != "." {
@@ -73,32 +73,32 @@ func (client *Client) AddFile(pushURL, id string, opts *options.PushOptions) err
 }
 
 func (client *Client) PreparePush(pushURL string, opts *options.PushOptions) error {
-	parsedURL := client.Parse(pushURL)
-	auth := &url.BasicAuth{Username: parsedURL.Username, Password: parsedURL.Password}
+	url := client.Parse(pushURL)
+	auth := &netutil.BasicAuth{Username: url.Username, Password: url.Password}
 
 	if opts.UseNetRC {
-		if err := auth.UseNetRC(parsedURL.Hostname); err != nil {
+		if err := auth.UseNetRC(url.Hostname); err != nil {
 			return fmt.Errorf("setting .netrc auth: %w", err)
 		}
 	}
 
 	// Clone the repository into memory.
-	return client.cloneRepo(parsedURL, auth, opts.Options)
+	return client.cloneRepo(url, auth, opts.Options)
 }
 
 func (client *Client) Push(pushURL string, opts *options.PushOptions) error {
-	parsedURL := client.Parse(pushURL)
-	auth := &url.BasicAuth{Username: parsedURL.Username, Password: parsedURL.Password}
+	url := client.Parse(pushURL)
+	auth := &netutil.BasicAuth{Username: url.Username, Password: url.Password}
 
 	if opts.UseNetRC {
-		if err := auth.UseNetRC(parsedURL.Hostname); err != nil {
+		if err := auth.UseNetRC(url.Hostname); err != nil {
 			return fmt.Errorf("failed to set auth: %w", err)
 		}
 	}
 
 	// Commit written SBOM file to cloned repo.
 	if _, err := client.worktree.Commit(
-		fmt.Sprintf("bomctl push of %s", parsedURL.Fragment), &git.CommitOptions{All: true},
+		fmt.Sprintf("bomctl push of %s", url.Fragment), &git.CommitOptions{All: true},
 	); err != nil {
 		return fmt.Errorf("committing worktree: %w", err)
 	}
@@ -106,7 +106,7 @@ func (client *Client) Push(pushURL string, opts *options.PushOptions) error {
 	// Push changes to remote repository.
 	if err := client.repo.Push(&git.PushOptions{Auth: auth}); err != nil {
 		if !errors.Is(err, git.NoErrAlreadyUpToDate) {
-			return fmt.Errorf("pushing to remote %s: %w", parsedURL, err)
+			return fmt.Errorf("pushing to remote %s: %w", url, err)
 		}
 
 		opts.Logger.Warn("Already up-to-date; no changes pushed to remote")

--- a/internal/pkg/client/http/client.go
+++ b/internal/pkg/client/http/client.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/bomctl/bomctl/internal/pkg/url"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 )
 
 type Client struct{}
@@ -43,7 +43,7 @@ func (*Client) RegExp() *regexp.Regexp {
 	)
 }
 
-func (client *Client) Parse(rawURL string) *url.ParsedURL {
+func (client *Client) Parse(rawURL string) *netutil.URL {
 	results := map[string]string{}
 	pattern := client.RegExp()
 	match := pattern.FindStringSubmatch(rawURL)
@@ -59,7 +59,7 @@ func (client *Client) Parse(rawURL string) *url.ParsedURL {
 		}
 	}
 
-	return &url.ParsedURL{
+	return &netutil.URL{
 		Scheme:   results["scheme"],
 		Username: results["username"],
 		Password: results["password"],

--- a/internal/pkg/client/http/client_test.go
+++ b/internal/pkg/client/http/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/bomctl/bomctl/internal/pkg/client/http"
-	"github.com/bomctl/bomctl/internal/pkg/url"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 )
 
 type httpClientSuite struct {
@@ -36,24 +36,24 @@ func (hcs *httpClientSuite) TestClient_Parse() {
 	client := &http.Client{}
 
 	for _, data := range []struct {
-		expected *url.ParsedURL
+		expected *netutil.URL
 		name     string
 		url      string
 	}{
 		{
 			name:     "HTTP scheme and hostname only",
 			url:      "http://example.acme.com",
-			expected: &url.ParsedURL{Scheme: "http", Hostname: "example.acme.com"},
+			expected: &netutil.URL{Scheme: "http", Hostname: "example.acme.com"},
 		},
 		{
 			name:     "HTTPS scheme and hostname only",
 			url:      "https://example.acme.com",
-			expected: &url.ParsedURL{Scheme: "https", Hostname: "example.acme.com"},
+			expected: &netutil.URL{Scheme: "https", Hostname: "example.acme.com"},
 		},
 		{
 			name:     "HTTPS username@hostname",
 			url:      "https://user@example.acme.com",
-			expected: &url.ParsedURL{Scheme: "https", Username: "user", Hostname: "example.acme.com"},
+			expected: &netutil.URL{Scheme: "https", Username: "user", Hostname: "example.acme.com"},
 		},
 		{
 			name:     "HTTP hostname only",

--- a/internal/pkg/client/http/fetch.go
+++ b/internal/pkg/client/http/fetch.go
@@ -25,30 +25,30 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
 func (client *Client) Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error) {
-	parsedURL := client.Parse(fetchURL)
-	auth := &url.BasicAuth{Username: parsedURL.Username, Password: parsedURL.Password}
+	url := client.Parse(fetchURL)
+	auth := &netutil.BasicAuth{Username: url.Username, Password: url.Password}
 
 	if opts.UseNetRC {
-		if err := auth.UseNetRC(parsedURL.Hostname); err != nil {
+		if err := auth.UseNetRC(url.Hostname); err != nil {
 			return nil, fmt.Errorf("failed to set auth: %w", err)
 		}
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", parsedURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating request to %s: %w", parsedURL.String(), err)
+		return nil, fmt.Errorf("failed creating request to %s: %w", url.String(), err)
 	}
 
 	auth.SetAuth(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed request to %s: %w", parsedURL.String(), err)
+		return nil, fmt.Errorf("failed request to %s: %w", url.String(), err)
 	}
 
 	defer resp.Body.Close()

--- a/internal/pkg/client/oci/client_test.go
+++ b/internal/pkg/client/oci/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/bomctl/bomctl/internal/pkg/client/oci"
-	"github.com/bomctl/bomctl/internal/pkg/url"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 )
 
 const testSHA string = "sha256:abcdef0123456789ABCDEF0123456789abcdef0123456789ABCDEF0123456789"
@@ -38,14 +38,14 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 	client := &oci.Client{}
 
 	for _, data := range []struct {
-		expected *url.ParsedURL
+		expected *netutil.URL
 		name     string
 		url      string
 	}{
 		{
 			name: "oci scheme",
 			url:  "oci://registry.acme.com/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Hostname: "registry.acme.com",
 				Path:     "example/image",
@@ -55,7 +55,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "oci-archive scheme",
 			url:  "oci-archive://registry.acme.com/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Hostname: "registry.acme.com",
 				Path:     "example/image",
@@ -65,7 +65,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "docker scheme",
 			url:  "docker://registry.acme.com/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Hostname: "registry.acme.com",
 				Path:     "example/image",
@@ -75,7 +75,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "docker-archive scheme",
 			url:  "docker-archive://registry.acme.com/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Hostname: "registry.acme.com",
 				Path:     "example/image",
@@ -85,7 +85,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "no scheme",
 			url:  "registry.acme.com/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Hostname: "registry.acme.com",
 				Path:     "example/image",
@@ -95,7 +95,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "oci scheme with username, port, tag",
 			url:  "oci://username@registry.acme.com:12345/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Username: "username",
 				Hostname: "registry.acme.com",
@@ -107,7 +107,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "oci scheme with username, password, port, tag",
 			url:  "oci://username:password@registry.acme.com:12345/example/image:1.2.3",
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Username: "username",
 				Password: "password",
@@ -120,7 +120,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "oci scheme with username, port, digest",
 			url:  "oci://username@registry.acme.com:12345/example/image@" + testSHA,
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Username: "username",
 				Hostname: "registry.acme.com",
@@ -132,7 +132,7 @@ func (ocs *ociClientSuite) TestClient_Parse() {
 		{
 			name: "oci scheme with username, password, port, digest",
 			url:  "oci://username:password@registry.acme.com:12345/example/image@" + testSHA,
-			expected: &url.ParsedURL{
+			expected: &netutil.URL{
 				Scheme:   "oci",
 				Username: "username",
 				Password: "password",

--- a/internal/pkg/client/oci/fetch.go
+++ b/internal/pkg/client/oci/fetch.go
@@ -28,28 +28,28 @@ import (
 	oras "oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
 func (client *Client) Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error) {
-	parsedURL := client.Parse(fetchURL)
-	auth := &url.BasicAuth{Username: parsedURL.Username, Password: parsedURL.Password}
+	url := client.Parse(fetchURL)
+	auth := &netutil.BasicAuth{Username: url.Username, Password: url.Password}
 
 	if opts.UseNetRC {
-		if err := auth.UseNetRC(parsedURL.Hostname); err != nil {
+		if err := auth.UseNetRC(url.Hostname); err != nil {
 			return nil, fmt.Errorf("failed to set auth: %w", err)
 		}
 	}
 
-	err := client.createRepository(parsedURL, auth, opts.Options)
+	err := client.createRepository(url, auth, opts.Options)
 	if err != nil {
 		return nil, err
 	}
 
-	ref := parsedURL.Tag
+	ref := url.Tag
 	if ref == "" {
-		ref = parsedURL.Digest
+		ref = url.Digest
 	}
 
 	copyOpts := oras.CopyOptions{CopyGraphOptions: oras.CopyGraphOptions{FindSuccessors: nil}}

--- a/internal/pkg/client/oci/internal_test.go
+++ b/internal/pkg/client/oci/internal_test.go
@@ -24,14 +24,14 @@ import (
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
 
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-	"github.com/bomctl/bomctl/internal/pkg/url"
 )
 
 var GetDocument = getDocument
 
-func (client *Client) CreateRepository(p *url.ParsedURL, a *url.BasicAuth, o *options.Options) error {
-	return client.createRepository(p, a, o)
+func (client *Client) CreateRepository(url *netutil.URL, auth *netutil.BasicAuth, opts *options.Options) error {
+	return client.createRepository(url, auth, opts)
 }
 
 func (client *Client) Descriptors() []ocispec.Descriptor {

--- a/internal/pkg/netutil/auth.go
+++ b/internal/pkg/netutil/auth.go
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
-// SPDX-FileName: internal/pkg/url/auth.go
+// SPDX-FileName: internal/pkg/netutil/auth.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // -----------------------------------------------------------------------------
@@ -17,7 +17,7 @@
 // limitations under the License.
 // -----------------------------------------------------------------------------
 
-package url
+package netutil
 
 import (
 	"encoding/base64"

--- a/internal/pkg/netutil/url.go
+++ b/internal/pkg/netutil/url.go
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
-// SPDX-FileName: internal/pkg/url/url.go
+// SPDX-FileName: internal/pkg/netutil/url.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // -----------------------------------------------------------------------------
@@ -17,7 +17,7 @@
 // limitations under the License.
 // -----------------------------------------------------------------------------
 
-package url
+package netutil
 
 import (
 	"errors"
@@ -28,7 +28,12 @@ import (
 )
 
 type (
-	ParsedURL struct {
+	Parser interface {
+		Parse(url string) *URL
+		RegExp() *regexp.Regexp
+	}
+
+	URL struct {
 		Scheme   string
 		Username string
 		Password string
@@ -41,16 +46,11 @@ type (
 		Tag      string
 		Digest   string
 	}
-
-	Parser interface {
-		Parse(fetchURL string) *ParsedURL
-		RegExp() *regexp.Regexp
-	}
 )
 
 var ErrParsingURL = errors.New("failed to parse URL")
 
-func (url *ParsedURL) String() string {
+func (url *URL) String() string {
 	var urlString, pathSep string
 
 	switch url.Scheme {

--- a/internal/pkg/outpututil/table.go
+++ b/internal/pkg/outpututil/table.go
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
-// SPDX-FileName: internal/pkg/outpututils/table.go
+// SPDX-FileName: internal/pkg/outpututil/table.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // -----------------------------------------------------------------------------
@@ -17,7 +17,7 @@
 // limitations under the License.
 // -----------------------------------------------------------------------------
 
-package outpututils
+package outpututil
 
 import (
 	"fmt"

--- a/internal/pkg/sliceutil/sliceutils.go
+++ b/internal/pkg/sliceutil/sliceutils.go
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
-// SPDX-FileName: internal/pkg/sliceutils/sliceutils.go
+// SPDX-FileName: internal/pkg/sliceutil/sliceutils.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // -----------------------------------------------------------------------------
@@ -17,7 +17,7 @@
 // limitations under the License.
 // -----------------------------------------------------------------------------
 
-package sliceutils
+package sliceutil
 
 import (
 	"errors"

--- a/internal/pkg/sliceutil/sliceutils_test.go
+++ b/internal/pkg/sliceutil/sliceutils_test.go
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
-// SPDX-FileName: internal/pkg/sliceutils/sliceutils_test.go
+// SPDX-FileName: internal/pkg/sliceutil/sliceutils_test.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // -----------------------------------------------------------------------------
@@ -17,7 +17,7 @@
 // limitations under the License.
 // -----------------------------------------------------------------------------
 
-package sliceutils_test
+package sliceutil_test
 
 import (
 	"strings"
@@ -25,7 +25,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/bomctl/bomctl/internal/pkg/sliceutils"
+	"github.com/bomctl/bomctl/internal/pkg/sliceutil"
 )
 
 type sliceutilsSuite struct {
@@ -67,7 +67,7 @@ func (ss *sliceutilsSuite) TestAll() {
 			expected: false,
 		},
 	} {
-		actual := sliceutils.All(data.items, data.cond)
+		actual := sliceutil.All(data.items, data.cond)
 
 		ss.Require().Equal(data.expected, actual)
 	}
@@ -108,7 +108,7 @@ func (ss *sliceutilsSuite) TestAny() {
 			expected: false,
 		},
 	} {
-		actual := sliceutils.Any(data.items, data.cond)
+		actual := sliceutil.Any(data.items, data.cond)
 
 		ss.Require().Equal(data.expected, actual)
 	}
@@ -130,7 +130,7 @@ func (ss *sliceutilsSuite) TestExtract() {
 			expected: []string{"", "one", "two", "three"},
 		},
 	} {
-		actual := sliceutils.Extract(data.items, data.cond)
+		actual := sliceutil.Extract(data.items, data.cond)
 
 		ss.Require().Equal(data.expected, actual)
 	}
@@ -164,7 +164,7 @@ func (ss *sliceutilsSuite) TestFilter() {
 			expected: []testStringValue{{"two"}, {"three"}},
 		},
 	} {
-		actual := sliceutils.Filter(data.items, data.cond)
+		actual := sliceutil.Filter(data.items, data.cond)
 
 		ss.Require().Equal(data.expected, actual)
 	}
@@ -179,7 +179,7 @@ func (ss *sliceutilsSuite) TestMap() {
 		items := []testIntValue{{0}, {1}, {2}, {3}, {4}, {5}}
 		expected := []testIntValue{{0}, {2}, {4}, {6}, {8}, {10}}
 
-		actual := sliceutils.Map(items, func(item testIntValue) testIntValue {
+		actual := sliceutil.Map(items, func(item testIntValue) testIntValue {
 			item.value *= 2
 
 			return item
@@ -196,7 +196,7 @@ func (ss *sliceutilsSuite) TestMap() {
 		items := []testStringValue{{"one"}, {"two"}, {"three"}, {"four"}}
 		expected := []testStringValue{{"one-mapped"}, {"two-mapped"}, {"three-mapped"}, {"four-mapped"}}
 
-		actual := sliceutils.Map(items, func(item testStringValue) testStringValue {
+		actual := sliceutil.Map(items, func(item testStringValue) testStringValue {
 			item.value += "-mapped"
 
 			return item
@@ -247,7 +247,7 @@ func (ss *sliceutilsSuite) TestNext() {
 			expected: testAnyValue{"two"},
 		},
 	} {
-		actual, err := sliceutils.Next(data.items, data.cond)
+		actual, err := sliceutil.Next(data.items, data.cond)
 
 		if data.shouldErr {
 			ss.Error(err)


### PR DESCRIPTION
## Description

This PR renames bomctl's internal utility packages to be more cohesive and representative of their intent.

- `outpututils` ---> `outpututil`
- `sliceutils` ---> `sliceutil`
- `url` ---> `netutil`
  - type `ParsedURL` ---> `URL`

It also renames all variables named `parsedURL` to `url` across the project. There are no logic changes.

## Type of change

- [X] Style

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings