### PR TITLE
ci: skip title check for dependabot PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -32,6 +32,7 @@ permissions:
 
 jobs:
   check-title:
+    if: ${{ !startsWith(github.event.pull_request.title, ':dependabot:') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

Skip conventional commit check if PR title starts `:dependabot:`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)