### PR TITLE
test: add cmd format/encoding unit tests, update e2e tests to increase coverage

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -20,7 +20,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -35,11 +34,6 @@ import (
 
 	"github.com/bomctl/bomctl/internal/pkg/export"
 	"github.com/bomctl/bomctl/internal/pkg/options"
-)
-
-var (
-	errEncodingNotSupported = errors.New("encoding not supported for selected format")
-	errFormatNotSupported   = errors.New("format not supported")
 )
 
 func exportCmd() *cobra.Command { //nolint:funlen
@@ -159,11 +153,11 @@ func parseFormat(formatStr, encoding string) (formats.Format, error) {
 	baseFormat := results["name"]
 	version := results["version"]
 
-	if err := validateFormat(baseFormat); err != nil {
+	if err := validateFormat(formatStr); err != nil {
 		return formats.EmptyFormat, err
 	}
 
-	if err := validateEncoding(formatStr, encoding); err != nil {
+	if err := validateEncoding(baseFormat, encoding); err != nil {
 		return formats.EmptyFormat, err
 	}
 

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,0 +1,216 @@
+// -----------------------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+// SPDX-FileName: cmd/export_test.go
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// -----------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bomctl/bomctl/cmd"
+)
+
+func Test_ParseFormat(t *testing.T) {
+	t.Parallel()
+
+	availableEncodings := cmd.EncodingOptions()
+	availableFormats := cmd.FormatOptions()
+
+	for _, format := range availableFormats {
+		formatBase := getFormatBase(format)
+		for _, encoding := range availableEncodings[formatBase] {
+			_, err := cmd.ParseFormat(format, encoding)
+			if err != nil {
+				t.Logf("unexpected error while parsing format: %s with encoding: %s. Err: %v", format, encoding, err)
+				t.FailNow()
+			}
+		}
+	}
+}
+
+func getFormatBase(fmt string) string {
+	if strings.Contains(fmt, formats.CDXFORMAT) {
+		return formats.CDXFORMAT
+	}
+
+	return formats.SPDXFORMAT
+}
+
+func Test_ParseSpecificFormat(t *testing.T) {
+	t.Parallel()
+
+	for _, data := range []struct {
+		name      string
+		format    string
+		encoding  string
+		expected  formats.Format
+		shouldErr bool
+	}{
+		{
+			name:      "Default spdx",
+			format:    formats.SPDXFORMAT,
+			encoding:  formats.JSON,
+			expected:  formats.SPDX23JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "spdx 2.3",
+			format:    "spdx-2.3",
+			encoding:  formats.JSON,
+			expected:  formats.SPDX23JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "xml spdx",
+			format:    formats.SPDXFORMAT,
+			encoding:  formats.XML,
+			expected:  formats.EmptyFormat,
+			shouldErr: true,
+		},
+		{
+			name:      "non-supported spdx",
+			format:    "spdx-0.7",
+			encoding:  formats.XML,
+			expected:  formats.EmptyFormat,
+			shouldErr: true,
+		},
+		{
+			name:      "Default CDX",
+			format:    formats.CDXFORMAT,
+			encoding:  formats.JSON,
+			expected:  formats.CDX15JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.0 json",
+			format:    "cyclonedx-1.0",
+			encoding:  formats.JSON,
+			expected:  formats.CDX10JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.1 json",
+			format:    "cyclonedx-1.1",
+			encoding:  formats.JSON,
+			expected:  formats.CDX11JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.2 json",
+			format:    "cyclonedx-1.2",
+			encoding:  formats.JSON,
+			expected:  formats.CDX12JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.3 json",
+			format:    "cyclonedx-1.3",
+			encoding:  formats.JSON,
+			expected:  formats.CDX13JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.4 json",
+			format:    "cyclonedx-1.4",
+			encoding:  formats.JSON,
+			expected:  formats.CDX14JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.5 json",
+			format:    "cyclonedx-1.5",
+			encoding:  formats.JSON,
+			expected:  formats.CDX15JSON,
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.0 xml",
+			format:    "cyclonedx-1.0",
+			encoding:  formats.XML,
+			expected:  formats.Format("application/vnd.cyclonedx+xml;version=1.0"),
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.1 xml",
+			format:    "cyclonedx-1.1",
+			encoding:  formats.XML,
+			expected:  formats.Format("application/vnd.cyclonedx+xml;version=1.1"),
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.2 xml",
+			format:    "cyclonedx-1.2",
+			encoding:  formats.XML,
+			expected:  formats.Format("application/vnd.cyclonedx+xml;version=1.2"),
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.3 xml",
+			format:    "cyclonedx-1.3",
+			encoding:  formats.XML,
+			expected:  formats.Format("application/vnd.cyclonedx+xml;version=1.3"),
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.4 xml",
+			format:    "cyclonedx-1.4",
+			encoding:  formats.XML,
+			expected:  formats.Format("application/vnd.cyclonedx+xml;version=1.4"),
+			shouldErr: false,
+		},
+		{
+			name:      "cyclonedx 1.5 xml",
+			format:    "cyclonedx-1.5",
+			encoding:  formats.XML,
+			expected:  formats.Format("application/vnd.cyclonedx+xml;version=1.5"),
+			shouldErr: false,
+		},
+		{
+			name:      "unknown encoding cyclonedx",
+			format:    formats.CDXFORMAT,
+			encoding:  "other",
+			expected:  formats.EmptyFormat,
+			shouldErr: true,
+		},
+		{
+			name:      "non-supported cyclonedx xml",
+			format:    "cyclonedx-7",
+			encoding:  formats.XML,
+			expected:  formats.EmptyFormat,
+			shouldErr: true,
+		},
+		{
+			name:      "non-supported cyclonedx json",
+			format:    "cyclonedx-1.23",
+			encoding:  formats.JSON,
+			expected:  formats.EmptyFormat,
+			shouldErr: true,
+		},
+	} {
+		got, err := cmd.ParseFormat(data.format, data.encoding)
+		if !data.shouldErr {
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, data.expected, got)
+	}
+}

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
-// SPDX-FileName: cmd/errors.go
+// SPDX-FileName: cmd/internal_test.go
 // SPDX-FileType: SOURCE
 // SPDX-License-Identifier: Apache-2.0
 // -----------------------------------------------------------------------------
@@ -19,12 +19,9 @@
 
 package cmd
 
-import "errors"
-
 var (
-	errDocumentNotFound     = errors.New("no documents found with the specified ID")
-	errEncodingNotSupported = errors.New("encoding not supported for selected format")
-	errFormatNotSupported   = errors.New("format not supported")
-	errDirNotFound          = errors.New("not a directory or does not exist")
-	errFileNotFound         = errors.New("not a file or does not exist")
+	TestCmd         = rootCmd()
+	EncodingOptions = encodingOptions
+	FormatOptions   = formatOptions
+	ParseFormat     = parseFormat
 )

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -39,11 +39,6 @@ type (
 	urlSliceValue       []string
 )
 
-var (
-	errDirNotFound  = errors.New("not a directory or does not exist")
-	errFileNotFound = errors.New("not a file or does not exist")
-)
-
 func checkDirectory(value string) {
 	directory, err := os.Stat(value)
 

--- a/internal/e2e/alias/alias_remove.txtar
+++ b/internal/e2e/alias/alias_remove.txtar
@@ -10,7 +10,7 @@ stdout .
 
 # alias remove --help
 exec bomctl alias remove --help --cache-dir $WORK
-! stderr . 
+! stderr .
 stdout .
 
 # help alias remove
@@ -23,38 +23,43 @@ stdout .
 stderr -count=1 '^Error: accepts between 1 and 2 arg\(s\), received 0$'
 ! stdout .
 
+# alias remove non-existent sbom (FAILURE EXPECTED)
+! exec bomctl alias remove --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79
+stderr -count=1 '^(FATAL db: no documents found with the specified ID)$'
+! stdout .
+
 # alias remove sbom_id
 exec bomctl import --cache-dir $WORK --alias apple sbom.cdx.json
 ! stdout .
-! stderr . 
+! stderr .
 
 exec bomctl list --cache-dir $WORK
-! stderr . 
+! stderr .
 cmp stdout apple_remove_list.txt
 
 exec bomctl alias remove --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79
-! stderr . 
+! stderr .
 ! stdout .
 
 exec bomctl list --cache-dir $WORK
-! stderr . 
+! stderr .
 cmp stdout empty_remove_list.txt
 
 # alias rm sbom_id
 exec bomctl alias set --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 orange
-! stderr . 
+! stderr .
 ! stdout .
 
 exec bomctl list --cache-dir $WORK
-! stderr . 
+! stderr .
 cmp stdout orange_remove_list.txt
 
 exec bomctl alias rm --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79
-! stderr . 
+! stderr .
 ! stdout .
 
 exec bomctl list --cache-dir $WORK
-! stderr . 
+! stderr .
 cmp stdout empty_remove_list.txt
 
 -- empty_remove_list.txt --

--- a/internal/e2e/alias/alias_set.txtar
+++ b/internal/e2e/alias/alias_set.txtar
@@ -20,12 +20,17 @@ stdout .
 
 # alias set no input (FAILURE EXPECTED)
 ! exec bomctl alias set --cache-dir $WORK
-stderr -count=1 '^Error: accepts 2 arg\(s\), received 0$'
+stderr -count=1 '^(Error: accepts 2 arg\(s\), received 0)$'
 ! stdout .
 
 # alias set one input (FAILURE EXPECTED)
 ! exec bomctl alias set --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79
-stderr -count=1 '^Error: accepts 2 arg\(s\), received 1$'
+stderr -count=1 '^(Error: accepts 2 arg\(s\), received 1)$'
+! stdout .
+
+# alias set non-existent sbom (FAILURE EXPECTED)
+! exec bomctl alias set --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 cheer_wine
+stderr -count=1 '^(FATAL db: no documents found with the specified ID)$'
 ! stdout .
 
 # alias set sbom_id
@@ -42,7 +47,7 @@ cmp stdout alias_set_list.txt
 
 # alias set same sbom with different alias (FAILURE EXPECTED)
 ! exec bomctl alias set --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 cherry_coke
-stderr 'FATAL db: The document already has an alias. To replace it, re-run the command with the --force flag'
+stderr '^(FATAL db: The document already has an alias. To replace it, re-run the command with the --force flag)$'
 ! stdout .
 
 # alias set sbom_id -f

--- a/internal/e2e/export/export.txtar
+++ b/internal/e2e/export/export.txtar
@@ -22,10 +22,26 @@ stdout .
 # export no input (FAILURE EXPECTED)
 ! exec bomctl export --cache-dir $WORK
 stderr -count=1 '^(Error: requires at least 1 arg\(s\), only received 0).*'
+! stdout .
 
 # export non-existent sbom
 exec bomctl export --cache-dir $WORK "super-cool-blaster-extreme"
 stderr '^(ERROR export: documentID\(s\) not found: \[\"super-cool-blaster-extreme\"\])$'
+! stdout .
+
+# export -o with two sboms (FAILURE EXPECTED)
+! exec bomctl export --cache-dir $WORK --output-file onyx.json testsbom1.json testsbom2.json
+stderr -count=1 '^(FATAL export: The --output-file option cannot be used when more than one SBOM is provided\.)$'
+! stdout .
+
+# export --output-file with two sboms (FAILURE EXPECTED)
+! exec bomctl export --cache-dir $WORK --output-file geodude.json testsbom1.json testsbom2.json
+stderr -count=1 '^(FATAL export: The --output-file option cannot be used when more than one SBOM is provided\.)$'
+! stdout .
+
+# export --output-file with non-workable filename(FAILURE EXPECTED)
+! exec bomctl export --cache-dir $WORK --output-file . testsbom.json
+stderr -count=1 '^(FATAL export: error creating output file outputFile=\.)$'
 ! stdout .
 
 # export cdx sbom
@@ -50,8 +66,7 @@ exists squirtle.json
 compare_docs $WORK squirtle.json test-linked.cdx.json
 
 # export spdx sbom
-# exec bomctl export --cache-dir $WORK -f spdx-2.3 spdx <-- this fails with: FATAL export: encoding not supported for selected format format=spdx-2.3 encoding=json
-exec bomctl export --cache-dir $WORK -f spdx 'https://anchore.com/syft/file/bomctl_0.3.0_linux_amd64.tar.gz-1b838d44-9d3c-47d0-9f7f-846397e701fa#DOCUMENT'
+exec bomctl export --cache-dir $WORK -f spdx-2.3 'https://anchore.com/syft/file/bomctl_0.3.0_linux_amd64.tar.gz-1b838d44-9d3c-47d0-9f7f-846397e701fa#DOCUMENT'
 stderr '^(INFO  export: Exporting document sbomID=https://anchore.com/syft/file/bomctl_0.3.0_linux_amd64.tar.gz-1b838d44-9d3c-47d0-9f7f-846397e701fa#DOCUMENT)$'
 stdout '.*("documentNamespace": "https://spdx.org/spdxdocs/",).*'
 

--- a/internal/e2e/fetch/fetch.txtar
+++ b/internal/e2e/fetch/fetch.txtar
@@ -22,6 +22,11 @@ stdout .
 stderr -count=1 '^(Error: requires at least 1 arg\(s\), only received 0).*'
 ! stdout .
 
+# fetch not valid --output-file (FAILURE EXPECTED)
+! exec bomctl fetch --cache-dir $WORK  -o . https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/bomctl_bomctl_v0.3.0.cdx.json
+stderr -count=1 '^(FATAL fetch: error creating output file outputFileName=\.)$'
+! stdout .
+
 # fetch --output-file
 [net] exec bomctl fetch --cache-dir $WORK -o first.cdx.json https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/bomctl_bomctl_v0.3.0.cdx.json
 cmp stderr fetch_linked.txt

--- a/internal/e2e/import/import.txtar
+++ b/internal/e2e/import/import.txtar
@@ -22,6 +22,16 @@ stdout .
 stderr -count=1 '^(Error: requires at least 1 arg\(s\), only received 0).*'
 ! stdout .
 
+# import non-existent file (FAILURE EXPECTED)
+! exec bomctl import --cache-dir $WORK test-1.sbom.json
+stderr -count=1 '^(FATAL import: failed to open input file err="open test-1\.sbom\.json: no such file or directory" file=<nil>)$'
+! stdout .
+
+# import stdin and file (FAILURE EXPECTED)
+! exec bomctl import --cache-dir $WORK - test-1.sbom.json
+stderr -count=1 '^(FATAL import: Piped input and file path args cannot be specified simultaneously\.)$'
+! stdout .
+
 # import from file
 exec bomctl import --cache-dir $WORK import_test.cdx.json
 ! stderr .
@@ -55,7 +65,7 @@ rm bomctl.db
 # import from file multiple tags
 exec bomctl import --cache-dir $WORK --tag strawberry --tag rocky_road import_test.cdx.json
 ! stdout .
-! stderr . 
+! stderr .
 
 exec bomctl tag list --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79
 ! stderr .
@@ -99,7 +109,7 @@ rm bomctl.db
 stdin import_test.cdx.json
 exec bomctl import --cache-dir $WORK --tag strawberry --tag rocky_road  -
 ! stdout .
-! stderr . 
+! stderr .
 
 exec bomctl tag list --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79
 ! stderr .

--- a/internal/e2e/list/list.txtar
+++ b/internal/e2e/list/list.txtar
@@ -28,9 +28,19 @@ exec bomctl ls --cache-dir $WORK
 cmp stdout list_no_input.txt
 ! stderr .
 
+# ls no document match for tag found
+exec bomctl ls --cache-dir $WORK --tag yeppers
+! stdout .
+! stderr .
+
+# ls no document match found
+exec bomctl ls --cache-dir $WORK --tag urn:uuid:8675309
+! stdout .
+! stderr .
+
 # list tag
 exec bomctl tag add --cache-dir $WORK urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 yeppers
-! stderr . 
+! stderr .
 ! stdout .
 
 exec bomctl list --cache-dir $WORK --tag yeppers


### PR DESCRIPTION
## Description

Adds unit tests and fixes for format/encoding helper functions in `cmd/export.go`. Added additional e2e tests to cover items not easily tested via unit tests. 

Fixes #127

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Additional e2e tests
- [ ] Unit tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
