### PR TITLE
chore: fix workflow header

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# SPDX-FileCopyrightText: Copyright © 2024 The Protobom Authors
+# SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
 # SPDX-FileName: .github/workflows/markdownlint.yml
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Description

Corrects copyright header in markdownlint workflow
