### PR TITLE
feat: add link command stubs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -190,6 +190,10 @@ linters-settings:
     enable:
       - fieldalignment
 
+  mnd:
+    ignored-functions:
+      - cobra.*Args
+
   nolintlint:
     allow-unused: false
     require-specific: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -192,7 +192,7 @@ linters-settings:
 
   mnd:
     ignored-functions:
-      - cobra.*Args
+      - ^cobra\.[A-Za-z]+Args$
 
   nolintlint:
     allow-unused: false

--- a/.taskfiles/lint.yml
+++ b/.taskfiles/lint.yml
@@ -21,12 +21,6 @@
 
 version: "3"
 
-env:
-  BOLD: \033[1m
-  CYAN: \033[36m
-  YELLOW: \033[33m
-  RESET: \033[0m
-
 tasks:
   run:
     silent: true
@@ -36,10 +30,10 @@ tasks:
     cmd: >
       export PATH="{{shellQuote .TOOLS_DIR}}{{eq OS "windows" | ternary ";" ":"}}{{env "PATH"}}";
       if command -v {{.CLI_NAME}} > /dev/null; then
-        printf "Running ${CYAN}{{.CLI_NAME}} {{.CLI_ARGS}}${RESET}\n";
+        printf "Running {{.CYAN}}{{.CLI_NAME}} {{.CLI_ARGS}}{{.RESET}}\n";
         {{.CLI_NAME}} {{.CLI_ARGS}};
       else
-        printf "${YELLOW}{{.CLI_NAME}} not found, please install and run the command again.${RESET}\n";
+        printf "{{.YELLOW}}{{.CLI_NAME}} not found, please install and run the command again.{{.RESET}}\n";
       fi
 
   go:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,15 @@ vars:
   YAML_FILES:
     sh: git ls-files '*.yml' '*.yaml'
 
+  # ANSI color escape codes
+  BOLD: \033[1m
+  CYAN: \033[38;5;51m
+  GREEN: \033[38;5;46m
+  ORANGE: \033[38;5;214m
+  YELLOW: \033[38;5;226m
+  RED: \033[38;5;196m
+  RESET: \033[0m
+
 tasks:
   default:
     silent: true
@@ -102,14 +111,57 @@ tasks:
       - task: lint:shell
       - task: lint:yaml
 
+  report-coverage:
+    silent: true
+    cmd: |
+      printf "{{.CYAN}}"
+      echo "+----------------------------------------------------------------------------------------+"
+      echo "|    COVERAGE REPORT                                                                     |"
+      echo "+----------------------------------------------------------------------------------------+"
+      printf "{{.RESET}}\n"
+
+      go tool cover -func=coverage.out |
+        awk -- '{
+          sub("github.com/bomctl/bomctl/", "", $1);
+          percent = +$3; sub("%", "", percent);
+          if (percent < 50.00) color = "{{.RED}}";
+          else if (percent < 80.00) color = "{{.ORANGE}}";
+          else if (percent < 100.00) color = "{{.YELLOW}}";
+          else color = "{{.GREEN}}";
+          fmtstr = $1 == "total:" ? "\n%s%s\t%s\t%s%s\n" : "%s%-48s %-32s %.1f%%%s\n";
+          printf fmtstr, color, $1, $2, $3, "{{.RESET}}"
+        }'
+
+  run-test:
+    silent: true
+    vars:
+      TEST_ARGS: '{{.TEST_ARGS | default list | join " "}}'
+      TEST_PATH: '{{.TEST_PATH | default "./..."}}'
+    cmds:
+      - cmd: printf "Running {{.CYAN}}go test -failfast -v {{.TEST_ARGS}} {{.TEST_PATH}}{{.RESET}}\n"
+      - cmd: go test -failfast -v {{.TEST_ARGS}} {{.TEST_PATH}}
+
   test:
     desc: Run all tests
-    cmd: go test -failfast -v -coverprofile=coverage.out -covermode=atomic ./...
+    cmds:
+      - task: run-test
+        vars:
+          TEST_ARGS: [-coverprofile=coverage.out, -covermode=atomic]
+
+      - task: report-coverage
 
   test:unit:
     desc: Run unit tests
-    cmd: go test -failfast -v -coverprofile=coverage.out -covermode=atomic -short ./...
+    cmds:
+      - task: run-test
+        vars:
+          TEST_ARGS: [-coverprofile=coverage.out, -covermode=atomic, -short]
+
+      - task: report-coverage
 
   test:e2e:
-    desc: Run unit tests
-    cmd: go test -failfast -v ./internal/e2e/...
+    desc: Run end-to-end tests
+    cmd:
+      task: run-test
+      vars:
+        TEST_PATH: ./internal/e2e/...

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -117,7 +117,7 @@ func aliasRemoveCmd() *cobra.Command {
 				backend.Logger.Fatal(err, "documentID", args[0])
 			}
 
-			if err := backend.RemoveAnnotations(document.GetMetadata().GetId(),
+			if err := backend.RemoveDocumentAnnotations(document.GetMetadata().GetId(),
 				db.AliasAnnotation, docAlias); err != nil {
 				backend.Logger.Fatal(err, "name", db.AliasAnnotation, "value", docAlias)
 			}

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -32,12 +32,6 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-const (
-	aliasRemoveMinArgNum = 1
-	aliasRemoveMaxArgNum = 2
-	aliasSetExactArgNum  = 2
-)
-
 func aliasCmd() *cobra.Command {
 	aliasCmd := &cobra.Command{
 		Use:   "alias",
@@ -97,7 +91,7 @@ func aliasRemoveCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove the alias for a specific document",
 		Long:    "Remove the alias for a specific document",
-		Args:    cobra.RangeArgs(aliasRemoveMinArgNum, aliasRemoveMaxArgNum),
+		Args:    cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
 
@@ -134,7 +128,7 @@ func aliasSetCmd() *cobra.Command {
 		Use:   "set [flags] SBOM_ID NEW_ALIAS",
 		Short: "Set the alias for a specific document",
 		Long:  "Set the alias for a specific document",
-		Args:  cobra.ExactArgs(aliasSetExactArgNum),
+		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			opts.Options = optionsFromContext(cmd)
 			backend := backendFromContext(cmd)

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -28,15 +28,13 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-const fetchMinArgs int = 1
-
 func fetchCmd() *cobra.Command {
 	opts := &options.FetchOptions{}
 	outputFileName := outputFileValue("")
 
 	fetchCmd := &cobra.Command{
 		Use:   "fetch [flags] SBOM_URL...",
-		Args:  cobra.MinimumNArgs(fetchMinArgs),
+		Args:  cobra.MinimumNArgs(1),
 		Short: "Fetch SBOM file(s) from HTTP(S), OCI, Git, or GitHub URLs",
 		Long:  "Fetch SBOM file(s) from HTTP(S), OCI, Git, or GitHub URLs",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -1,0 +1,142 @@
+// -----------------------------------------------------------------------------
+// SPDX-FileCopyrightText: Copyright © 2024 bomctl a Series of LF Projects, LLC
+// SPDX-FileName: cmd/link.go
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Apache-2.0
+// -----------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func linkCmd() *cobra.Command {
+	linkCmd := &cobra.Command{
+		Use:   "link",
+		Short: "Edit links between documents and/or nodes",
+		Long:  "Edit links between documents and/or nodes",
+	}
+
+	linkCmd.AddCommand(linkAddCmd(), linkClearCmd(), linkListCmd(), linkRemoveCmd())
+
+	return linkCmd
+}
+
+func linkAddCmd() *cobra.Command {
+	addCmd := &cobra.Command{
+		Use:   "add [flags] {node:NODE_ID | document:SBOM_ID} [document:]SBOM_ID",
+		Short: "Add a link from a document or node to a document",
+		Long:  "Add a link from a document or node to a document",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			opts := optionsFromContext(cmd)
+			backend := backendFromContext(cmd)
+
+			defer backend.CloseClient()
+
+			if !(strings.HasPrefix(args[0], "document:") || strings.HasPrefix(args[0], "node:")) {
+				opts.Logger.Fatal(
+					"Must be prefixed with either 'document:' or 'node:'", "argument", args[0],
+				)
+			}
+
+			opts.Logger.Warn("Not yet implemented.")
+		},
+	}
+
+	return addCmd
+}
+
+func linkClearCmd() *cobra.Command {
+	clearCmd := &cobra.Command{
+		Use:   "clear [flags] {node:NODE_ID | document:SBOM_ID}...",
+		Short: "Remove all links from specified documents and nodes",
+		Long:  "Remove all links from specified documents and nodes",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			opts := optionsFromContext(cmd)
+			backend := backendFromContext(cmd)
+
+			defer backend.CloseClient()
+
+			for _, arg := range args {
+				if !(strings.HasPrefix(arg, "document:") || strings.HasPrefix(arg, "node:")) {
+					opts.Logger.Fatal(
+						"Positional arguments must be prefixed with either 'document:' or 'node:'", "argument", arg,
+					)
+				}
+			}
+
+			opts.Logger.Warn("Not yet implemented.")
+		},
+	}
+
+	return clearCmd
+}
+
+func linkListCmd() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:     "list [flags] {node:NODE_ID | document:SBOM_ID}",
+		Aliases: []string{"ls"},
+		Short:   "List the links of a document or node",
+		Long:    "List the links of a document or node",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			opts := optionsFromContext(cmd)
+			backend := backendFromContext(cmd)
+
+			defer backend.CloseClient()
+
+			if !(strings.HasPrefix(args[0], "document:") || strings.HasPrefix(args[0], "node:")) {
+				opts.Logger.Fatal(
+					"Must be prefixed with either 'document:' or 'node:'", "argument", args[0],
+				)
+			}
+
+			opts.Logger.Warn("Not yet implemented.")
+		},
+	}
+
+	return listCmd
+}
+
+func linkRemoveCmd() *cobra.Command {
+	removeCmd := &cobra.Command{
+		Use:     "remove [flags] {node:NODE_ID | document:SBOM_ID} [document:]SBOM_ID...",
+		Aliases: []string{"rm"},
+		Short:   "Remove specified links from a document or node",
+		Long:    "Remove specified links from a document or node",
+		Args:    cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			opts := optionsFromContext(cmd)
+			backend := backendFromContext(cmd)
+
+			defer backend.CloseClient()
+
+			if !(strings.HasPrefix(args[0], "document:") || strings.HasPrefix(args[0], "node:")) {
+				opts.Logger.Fatal(
+					"Must be prefixed with either 'document:' or 'node:'", "argument", args[0],
+				)
+			}
+
+			opts.Logger.Warn("Not yet implemented.")
+		},
+	}
+
+	return removeCmd
+}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -28,14 +28,12 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-const mergeMinArgs int = 2
-
 func mergeCmd() *cobra.Command {
 	opts := &options.MergeOptions{}
 
 	mergeCmd := &cobra.Command{
 		Use:   "merge [flags] DOCUMENT_ID...",
-		Args:  cobra.MinimumNArgs(mergeMinArgs),
+		Args:  cobra.MinimumNArgs(2),
 		Short: "Merge SBOM documents in local storage",
 		Long: fmt.Sprintf("%s%s%s",
 			"Merge SBOM documents in local storage. The leftmost specified document ID takes priority with the ",

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -27,14 +27,12 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/push"
 )
 
-const pushArgNum = 2
-
 func pushCmd() *cobra.Command {
 	opts := &options.PushOptions{}
 
 	pushCmd := &cobra.Command{
 		Use:   "push [flags] SBOM_ID DEST_PATH",
-		Args:  cobra.MinimumNArgs(pushArgNum),
+		Args:  cobra.MinimumNArgs(2),
 		Short: "Push stored SBOM file to remote URL or filesystem",
 		Long:  "Push stored SBOM file to remote URL or filesystem",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -30,13 +30,6 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/db"
 )
 
-const (
-	tagAddMinArgs     = 2
-	tagClearExactArgs = 1
-	tagListExactArgs  = 1
-	tagRemoveMinArgs  = 2
-)
-
 func tagCmd() *cobra.Command {
 	tagCmd := &cobra.Command{
 		Use:   "tag",
@@ -54,7 +47,7 @@ func tagAddCmd() *cobra.Command {
 		Use:   "add [flags] SBOM_ID TAGS...",
 		Short: "Add tags to a document",
 		Long:  "Add tags to a document",
-		Args:  cobra.MinimumNArgs(tagAddMinArgs),
+		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
 
@@ -84,7 +77,7 @@ func tagClearCmd() *cobra.Command {
 		Use:   "clear [flags] SBOM_ID...",
 		Short: "Clear all tags from a document",
 		Long:  "Clear all tags from a document",
-		Args:  cobra.ExactArgs(tagClearExactArgs),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
 
@@ -120,7 +113,7 @@ func tagListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List the tags of a document",
 		Long:    "List the tags of a document",
-		Args:    cobra.ExactArgs(tagListExactArgs),
+		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
 
@@ -156,7 +149,7 @@ func tagRemoveCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove specified tags from a document",
 		Long:    "Remove specified tags from a document",
-		Args:    cobra.MinimumNArgs(tagRemoveMinArgs),
+		Args:    cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			backend := backendFromContext(cmd)
 

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -69,7 +69,7 @@ func tagAddCmd() *cobra.Command {
 				backend.Logger.Fatal(errDocumentNotFound)
 			}
 
-			if err := backend.AddAnnotations(document.GetMetadata().GetId(),
+			if err := backend.AddDocumentAnnotations(document.GetMetadata().GetId(),
 				db.TagAnnotation, args[1:]...); err != nil {
 				backend.Logger.Fatalf("failed to add tags: %v", err)
 			}
@@ -104,7 +104,7 @@ func tagClearCmd() *cobra.Command {
 				backend.Logger.Fatalf("failed to clear tags: %v", err)
 			}
 
-			err = backend.RemoveAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, tagsToRemove...)
+			err = backend.RemoveDocumentAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, tagsToRemove...)
 			if err != nil {
 				backend.Logger.Fatalf("failed to clear tags: %v", err)
 			}
@@ -171,7 +171,7 @@ func tagRemoveCmd() *cobra.Command {
 				backend.Logger.Fatal(errDocumentNotFound)
 			}
 
-			err = backend.RemoveAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, args[1:]...)
+			err = backend.RemoveDocumentAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, args[1:]...)
 			if err != nil {
 				backend.Logger.Fatalf("failed to remove tags: %v", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/protobom/protobom v0.5.0
-	github.com/protobom/storage v0.1.6-0.20241114015657-685d55dfe2f3
+	github.com/protobom/storage v0.1.6-0.20241119201645-3bdeec73f95d
 	github.com/rogpeppe/go-internal v1.13.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/protobom/protobom v0.5.0 h1:jJYqGpdHq99zwh0/n1SOPl1aickCBZdA8pHS9V/f+XQ=
 github.com/protobom/protobom v0.5.0/go.mod h1:HL47tggz7SXYXgNm3WjQQrWB6iOirYnrATsXAEyTUkI=
-github.com/protobom/storage v0.1.6-0.20241114015657-685d55dfe2f3 h1:BYYHz0DJgfuAd6Iyk+R/6peHaX2u17q9UaAj5nCD7xM=
-github.com/protobom/storage v0.1.6-0.20241114015657-685d55dfe2f3/go.mod h1:eIeVcDaWqOKLngwKwTjJsoKbsh0G1KRekOEv3MnHNhs=
+github.com/protobom/storage v0.1.6-0.20241119201645-3bdeec73f95d h1:hvCfabf4pbbdvCbL+GKxN5PHRS4VKcjfUV2w3iGJSto=
+github.com/protobom/storage v0.1.6-0.20241119201645-3bdeec73f95d/go.mod h1:P5b3FGbQG8loixD6V0IkwBSZGFOwF1OHdPd5YtjlqeY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -250,12 +250,12 @@ func (backend *Backend) SetAlias(documentID, alias string, force bool) (err erro
 			return ErrDocumentAliasExists
 		}
 
-		if err := backend.RemoveAnnotations(documentID, AliasAnnotation, docAlias); err != nil {
+		if err := backend.RemoveDocumentAnnotations(documentID, AliasAnnotation, docAlias); err != nil {
 			return fmt.Errorf("failed to remove previous alias: %w", err)
 		}
 	}
 
-	if err := backend.SetUniqueAnnotation(documentID, AliasAnnotation, alias); err != nil {
+	if err := backend.SetDocumentUniqueAnnotation(documentID, AliasAnnotation, alias); err != nil {
 		return fmt.Errorf("failed to set alias: %w", err)
 	}
 

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -202,12 +202,12 @@ func (dbs *dbSuite) TestSetAlias() {
 		},
 	} {
 		dbs.Run(data.name, func() {
-			err := dbs.Backend.RemoveAnnotations(docs[0].GetMetadata().GetId(), db.AliasAnnotation, "cdx")
+			err := dbs.Backend.RemoveDocumentAnnotations(docs[0].GetMetadata().GetId(), db.AliasAnnotation, "cdx")
 			dbs.Require().NoError(err)
 
 			if data.doc0Alias != "" {
 				dbs.Require().NoError(
-					dbs.Backend.SetUniqueAnnotation(docs[0].GetMetadata().GetId(), db.AliasAnnotation, data.doc0Alias),
+					dbs.Backend.SetDocumentUniqueAnnotation(docs[0].GetMetadata().GetId(), db.AliasAnnotation, data.doc0Alias),
 					"failed to set alias", "err", err,
 				)
 			}

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -158,6 +158,8 @@ func (dbs *dbSuite) TestSetAlias() {
 	docs, err := dbs.Backend.GetDocumentsByID()
 	dbs.Require().NoError(err)
 
+	id := docs[0].GetMetadata().GetId()
+
 	for _, data := range []struct {
 		name      string
 		alias     string
@@ -202,21 +204,20 @@ func (dbs *dbSuite) TestSetAlias() {
 		},
 	} {
 		dbs.Run(data.name, func() {
-			err := dbs.Backend.RemoveDocumentAnnotations(docs[0].GetMetadata().GetId(), db.AliasAnnotation, "cdx")
+			err := dbs.Backend.RemoveDocumentAnnotations(id, db.AliasAnnotation, "cdx")
 			dbs.Require().NoError(err)
 
 			if data.doc0Alias != "" {
 				dbs.Require().NoError(
-					dbs.Backend.SetDocumentUniqueAnnotation(docs[0].GetMetadata().GetId(), db.AliasAnnotation, data.doc0Alias),
+					dbs.Backend.SetDocumentUniqueAnnotation(id, db.AliasAnnotation, data.doc0Alias),
 					"failed to set alias", "err", err,
 				)
 			}
 
-			err = dbs.Backend.SetAlias(docs[0].GetMetadata().GetId(), data.alias, data.force)
+			err = dbs.Backend.SetAlias(id, data.alias, data.force)
 			if data.errorMsg == "" {
 				dbs.Require().NoError(err)
-				docAlias, err := dbs.Backend.GetDocumentUniqueAnnotation(
-					docs[0].GetMetadata().GetId(), db.AliasAnnotation)
+				docAlias, err := dbs.Backend.GetDocumentUniqueAnnotation(id, db.AliasAnnotation)
 				dbs.Require().NoError(err)
 				dbs.Require().Equal(data.alias, docAlias)
 			} else {

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -65,7 +65,7 @@ func Fetch(sbomURL string, opts *options.FetchOptions) (*sbom.Document, error) {
 		return nil, fmt.Errorf("failed to save document: %w", err)
 	}
 
-	if err := backend.SetUniqueAnnotation(
+	if err := backend.SetDocumentUniqueAnnotation(
 		document.GetMetadata().GetId(), db.SourceURLAnnotation, sbomURL,
 	); err != nil {
 		return nil, fmt.Errorf("applying unique annotation %s to %s: %w",
@@ -149,7 +149,7 @@ func saveDocument(data []byte, backend *db.Backend, opts *options.FetchOptions) 
 		}
 	}
 
-	if err := backend.AddAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...); err != nil {
+	if err := backend.AddDocumentAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...); err != nil {
 		opts.Logger.Warn("Tag(s) could not be set.", "err", err)
 	}
 

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -149,7 +149,9 @@ func saveDocument(data []byte, backend *db.Backend, opts *options.FetchOptions) 
 		}
 	}
 
-	if err := backend.AddDocumentAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...); err != nil {
+	if err := backend.AddDocumentAnnotations(
+		document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...,
+	); err != nil {
 		opts.Logger.Warn("Tag(s) could not be set.", "err", err)
 	}
 

--- a/internal/pkg/import/import.go
+++ b/internal/pkg/import/import.go
@@ -65,7 +65,7 @@ func saveDocument(backend *db.Backend, documentFile *os.File, alias string, opts
 		}
 	}
 
-	if err := backend.AddAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...); err != nil {
+	if err := backend.AddDocumentAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...); err != nil {
 		opts.Logger.Warn("Tag(s) could not be set.", "err", err)
 	}
 

--- a/internal/pkg/import/import.go
+++ b/internal/pkg/import/import.go
@@ -65,7 +65,9 @@ func saveDocument(backend *db.Backend, documentFile *os.File, alias string, opts
 		}
 	}
 
-	if err := backend.AddDocumentAnnotations(document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...); err != nil {
+	if err := backend.AddDocumentAnnotations(
+		document.GetMetadata().GetId(), db.TagAnnotation, opts.Tags...,
+	); err != nil {
 		opts.Logger.Warn("Tag(s) could not be set.", "err", err)
 	}
 

--- a/internal/pkg/merge/merge.go
+++ b/internal/pkg/merge/merge.go
@@ -73,7 +73,7 @@ func Merge(documentIDs []string, opts *options.MergeOptions) (string, error) {
 		}
 	}
 
-	if err := backend.AddAnnotations(merged.GetMetadata().GetId(), db.TagAnnotation, tags...); err != nil {
+	if err := backend.AddDocumentAnnotations(merged.GetMetadata().GetId(), db.TagAnnotation, tags...); err != nil {
 		opts.Logger.Warn("Tag(s) could not be set.", "err", err)
 	}
 

--- a/internal/pkg/outpututil/file_test.go
+++ b/internal/pkg/outpututil/file_test.go
@@ -85,7 +85,7 @@ func (fs *fileSuite) TestCheckIfModified() {
 			docNum: 1,
 			prepare: func() {
 				docID := tempdocs[1].Document.GetMetadata().GetId()
-				err := tempbe.ClearAnnotations(docID)
+				err := tempbe.ClearDocumentAnnotations(docID)
 				fs.Require().NoError(err)
 			},
 			expectedValue: true,
@@ -95,7 +95,7 @@ func (fs *fileSuite) TestCheckIfModified() {
 			docNum: 0,
 			prepare: func() {
 				docID := tempdocs[0].Document.GetMetadata().GetId()
-				err := tempbe.SetUniqueAnnotation(docID, db.SourceDataAnnotation, "")
+				err := tempbe.SetDocumentUniqueAnnotation(docID, db.SourceDataAnnotation, "")
 				fs.Require().NoError(err)
 			},
 			expectedValue: true,

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -74,13 +74,13 @@ func AddTestDocuments(backend *db.Backend) ([]DocumentInfo, error) {
 
 		name := strings.Split(sboms[idx].Name(), ".")[1]
 
-		if err := backend.SetUniqueAnnotation(doc.GetMetadata().GetId(), db.AliasAnnotation, name); err != nil {
+		if err := backend.SetDocumentUniqueAnnotation(doc.GetMetadata().GetId(), db.AliasAnnotation, name); err != nil {
 			return nil, fmt.Errorf("setting alias: %w", err)
 		}
 
 		tags := []string{"tag" + strconv.Itoa(idx+1), "tag" + strconv.Itoa(idx+2)} //nolint:mnd
 
-		if err := backend.AddAnnotations(doc.GetMetadata().GetId(), db.TagAnnotation, tags...); err != nil {
+		if err := backend.AddDocumentAnnotations(doc.GetMetadata().GetId(), db.TagAnnotation, tags...); err != nil {
 			return nil, fmt.Errorf("adding tags: %w", err)
 		}
 


### PR DESCRIPTION
## Description

This PR adds stubs for the link command and its subcommands.

### Miscellaneous

- Update protobom/storage dependency and refactor
- Exclude `cobra.*Args` from `mnd` linter (magic number detection)

Closes #220

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings