### PR TITLE
refactor: add client PrepareFetch method

### DIFF
--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -21,33 +21,29 @@ package client
 
 import (
 	"errors"
-	"fmt"
 
-	"github.com/bomctl/bomctl/internal/pkg/client/git"
-	"github.com/bomctl/bomctl/internal/pkg/client/github"
-	"github.com/bomctl/bomctl/internal/pkg/client/http"
-	"github.com/bomctl/bomctl/internal/pkg/client/oci"
 	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-var errUnsupportedURL = errors.New("failed to parse URL; see `--help` for valid URL patterns")
+var ErrUnsupportedURL = errors.New("failed to parse URL; see `--help` for valid URL patterns")
 
-type Client interface {
-	netutil.Parser
-	AddFile(pushURL, id string, opts *options.PushOptions) error
-	Name() string
-	Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error)
-	PreparePush(pushURL string, opts *options.PushOptions) error
-	Push(pushURL string, opts *options.PushOptions) error
-}
-
-func New(sbomURL string) (Client, error) {
-	for _, client := range []Client{&github.Client{}, &git.Client{}, &http.Client{}, &oci.Client{}} {
-		if url := client.Parse(sbomURL); url != nil {
-			return client, nil
-		}
+type (
+	Client interface {
+		netutil.Parser
+		Name() string
 	}
 
-	return nil, fmt.Errorf("%w: %s", errUnsupportedURL, sbomURL)
-}
+	Fetcher interface {
+		Client
+		Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error)
+		PrepareFetch(url *netutil.URL, auth *netutil.BasicAuth, opts *options.Options) error
+	}
+
+	Pusher interface {
+		Client
+		AddFile(pushURL, id string, opts *options.PushOptions) error
+		PreparePush(pushURL string, opts *options.PushOptions) error
+		Push(pushURL string, opts *options.PushOptions) error
+	}
+)

--- a/internal/pkg/client/git/fetch.go
+++ b/internal/pkg/client/git/fetch.go
@@ -27,20 +27,12 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
-func (client *Client) Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error) {
+func (client *Client) PrepareFetch(url *netutil.URL, auth *netutil.BasicAuth, opts *options.Options) error {
+	return client.cloneRepo(url, auth, opts)
+}
+
+func (client *Client) Fetch(fetchURL string, _opts *options.FetchOptions) ([]byte, error) {
 	url := client.Parse(fetchURL)
-	auth := netutil.NewBasicAuth(url.Username, url.Password)
-
-	if opts.UseNetRC {
-		if err := auth.UseNetRC(url.Hostname); err != nil {
-			return nil, fmt.Errorf("failed to set auth: %w", err)
-		}
-	}
-
-	// Clone the repository into the temp directory
-	if err := client.cloneRepo(url, auth, opts.Options); err != nil {
-		return nil, err
-	}
 
 	// Read the file specified in the URL fragment.
 	file, err := client.worktree.Filesystem.Open(url.Fragment)

--- a/internal/pkg/client/git/fetch_test.go
+++ b/internal/pkg/client/git/fetch_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/bomctl/bomctl/internal/pkg/db"
+	"github.com/bomctl/bomctl/internal/pkg/netutil"
 	"github.com/bomctl/bomctl/internal/pkg/options"
 	"github.com/bomctl/bomctl/internal/testutil"
 )
@@ -45,6 +46,8 @@ func (gfs *gitFetchSuite) TestClient_Fetch() {
 			opts := &options.FetchOptions{Options: gfs.Options}
 
 			fetchURL := fmt.Sprintf("%s/test/repo.git@main#path/to/sbom.%s.json", gfs.Server.URL, alias)
+
+			gfs.Require().NoError(gfs.PrepareFetch(gfs.Parse(fetchURL), netutil.NewBasicAuth("", ""), opts.Options))
 
 			got, err := gfs.Fetch(fetchURL, opts)
 			gfs.Require().NoError(err)

--- a/internal/pkg/client/github/fetch.go
+++ b/internal/pkg/client/github/fetch.go
@@ -33,6 +33,10 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
+func (*Client) PrepareFetch(_url *netutil.URL, _auth *netutil.BasicAuth, _opts *options.Options) error {
+	return nil
+}
+
 func (client *Client) Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error) {
 	url := client.Parse(fetchURL)
 	ctx := context.Background()

--- a/internal/pkg/client/http/fetch.go
+++ b/internal/pkg/client/http/fetch.go
@@ -29,6 +29,10 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
+func (*Client) PrepareFetch(_url *netutil.URL, _auth *netutil.BasicAuth, _opts *options.Options) error {
+	return nil
+}
+
 func (client *Client) Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error) {
 	url := client.Parse(fetchURL)
 	auth := netutil.NewBasicAuth(url.Username, url.Password)

--- a/internal/pkg/client/oci/fetch.go
+++ b/internal/pkg/client/oci/fetch.go
@@ -32,20 +32,12 @@ import (
 	"github.com/bomctl/bomctl/internal/pkg/options"
 )
 
+func (client *Client) PrepareFetch(url *netutil.URL, auth *netutil.BasicAuth, opts *options.Options) error {
+	return client.createRepository(url, auth, opts)
+}
+
 func (client *Client) Fetch(fetchURL string, opts *options.FetchOptions) ([]byte, error) {
 	url := client.Parse(fetchURL)
-	auth := netutil.NewBasicAuth(url.Username, url.Password)
-
-	if opts.UseNetRC {
-		if err := auth.UseNetRC(url.Hostname); err != nil {
-			return nil, fmt.Errorf("failed to set auth: %w", err)
-		}
-	}
-
-	err := client.createRepository(url, auth, opts.Options)
-	if err != nil {
-		return nil, err
-	}
 
 	ref := url.Tag
 	if ref == "" {


### PR DESCRIPTION
## Description

This PR adds the `PrepareFetch` method to the `Client` interface definition. It also separates the concerns of fetching vs pushing by breaking out two new interfaces from the `Client` interface called `Fetcher` and `Pusher`.

Fixes #244

## Type of change

- Refactor

## How Has This Been Tested?

- [X] Unit/e2e tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings