### PR TITLE
fix: Handle pushing new artifacts

### DIFF
--- a/internal/pkg/client/oci/client_test.go
+++ b/internal/pkg/client/oci/client_test.go
@@ -183,9 +183,9 @@ func (otr *ociTestRepository) blobsHandler() http.Handler {
 }
 
 func (otr *ociTestRepository) blobsUploadsHandler() http.Handler {
-	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		uploadUUID := uuid.NewString()
+	uploadUUID := uuid.NewString()
 
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == http.MethodPost:
 			resp.Header().Set("Content-Length", "0")


### PR DESCRIPTION
## Description

During playground testing, kept getting a `application/vnd.oci.empty.v1+json: not found` error when pushing a new artifact, specifically if the repo/artifact didn't already exist in the registry with other tags. This aims to fix that. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
